### PR TITLE
Convert to sidecar charm

### DIFF
--- a/charms/jupyter-ui/config.yaml
+++ b/charms/jupyter-ui/config.yaml
@@ -15,3 +15,12 @@ options:
     type: boolean
     default: true
     description: If true, deactives SubjectAccessReview checks
+  default_notebook_lists:
+    type: string
+    default: "default"
+    description: |
+      Comma separated list of available jupyter notebook urls. The default list is the following:
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -4,7 +4,13 @@ summary: Multi-user server for Jupyter notebooks
 description: Multi-user server for Jupyter notebooks
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [ai, bigdata, kubeflow, machine-learning, tensorflow]
-series: [kubernetes]
+containers:
+  jupyter-ui:
+    resource: oci-image
+    mounts:
+      - storage: config
+        location: /etc/config
+
 resources:
   oci-image:
     type: oci-image
@@ -14,9 +20,14 @@ resources:
     # https://github.com/kubeflow/kubeflow/pull/5686
     # upstream-source: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
     upstream-source: rocks.canonical.com:5000/kubeflow/jupyter-ui:2d285b8
+
+storage:
+  config:
+    type: filesystem
+    location: /etc/config
+
 requires:
   ingress:
     interface: ingress
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress.yaml
     versions: [v1]
-min-juju-version: 2.8.6

--- a/charms/jupyter-ui/requirements-dev.txt
+++ b/charms/jupyter-ui/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+coverage
+flake8

--- a/charms/jupyter-ui/requirements.txt
+++ b/charms/jupyter-ui/requirements.txt
@@ -1,3 +1,3 @@
-ops==1.1.0
-oci-image==1.0.0
+ops >= 1.2.0
+kubernetes
 serialized-data-interface==0.2.0

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -114,7 +114,13 @@ class JupyterUICharm(CharmBase):
                 }
         config_template = None
         with open(Path('src/spawner_ui_config.yaml')) as file:
-            config_template = yaml.full_load(file)   
+            config_template = yaml.full_load(file)
+        # Configure jupyter notebook url list
+        if config['default_notebook_lists'] != "default":
+            config_template['spawnerFormDefaults']['image']['options'] = \
+                                            config['default_notebook_lists'].split(',')
+            config_template['spawnerFormDefaults']['image']['value'] = \
+                                            config['default_notebook_lists'].split(',')[0]
         # Add a Pebble config layer to the scraper container
         container = self.unit.get_container("jupyter-ui")
         container.push("/etc/config/spawner_ui_config.yaml", yaml.dump(config_template))

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -1,24 +1,30 @@
 #!/usr/bin/env python3
 
 import logging
-from pathlib import Path
+import urllib
+import os
+import yaml
 
 from ops.charm import CharmBase
 from ops.main import main
+from kubernetes import kubernetes
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
-from oci_image import OCIImageResource, OCIImageResourceError
+from pathlib import Path
 
-log = logging.getLogger()
+import resources
+
+logger = logging.getLogger(__name__)
 
 
-class Operator(CharmBase):
+class JupyterUICharm(CharmBase):
+    _authed = False
+    """Charm the service."""
     def __init__(self, *args):
         super().__init__(*args)
 
         if not self.model.unit.is_leader():
-            log.info("Not a leader, skipping set_pod_spec")
             self.model.unit.status = ActiveStatus()
             return
 
@@ -33,11 +39,9 @@ class Operator(CharmBase):
         else:
             self.model.unit.status = ActiveStatus()
 
-        self.image = OCIImageResource(self, "oci-image")
-
-        self.framework.observe(self.on.install, self.set_pod_spec)
-        self.framework.observe(self.on.upgrade_charm, self.set_pod_spec)
-        self.framework.observe(self.on.config_changed, self.set_pod_spec)
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.remove, self._on_remove)
 
         self.framework.observe(self.on.install, self.send_info)
         self.framework.observe(self.on.upgrade_charm, self.send_info)
@@ -54,92 +58,101 @@ class Operator(CharmBase):
                 }
             )
 
-    def set_pod_spec(self, event):
-        try:
-            image_details = self.image.fetch()
-        except OCIImageResourceError as e:
-            self.model.unit.status = e.status
-            log.info(e)
+    def _on_install(self, _):
+        """Handle the install event, create Kubernetes resources"""
+        logging.info("INSTALLING ......")
+        if not self._k8s_auth():
+            event.defer()
             return
-
+        self.unit.status = MaintenanceStatus("creating k8s resources")
+        # Create the Kubernetes resources needed for the Dashboard
+        r = resources.JupyterUIResources(self)
+        r.apply()
+    
+    def _on_remove(self, event):
+        """Cleanup Kubernetes resources"""
+        # Authenticate with the Kubernetes API
+        if not self._k8s_auth():
+            event.defer()
+            return
+        # Remove created Kubernetes resources
+        r = resources.JupyterUIResources(self)
+        r.delete()
+    
+    def _on_config_changed(self, event):
+        # Defer the config-changed event if we do not have sufficient privileges
+        if not self._k8s_auth():
+            event.defer()
+            return
+        try:
+            self._config_ui()
+        except ConnectionError:
+            logger.info("pebble socket not available, deferring config-changed")
+            event.defer()
+            return
+        self.unit.status = ActiveStatus()
+    
+    def _config_ui(self):
+        """Configure Pebble to start the Jupyter ui"""
+        # Define a simple layer
         config = self.model.config
-        self.model.unit.status = MaintenanceStatus("Setting pod spec")
-        self.model.pod.set_spec(
-            {
-                "version": 3,
-                "serviceAccount": {
-                    "roles": [
-                        {
-                            "global": True,
-                            "rules": [
-                                {
-                                    'apiGroups': [''],
-                                    'resources': ['namespaces'],
-                                    'verbs': ['get', 'list', 'create', 'delete'],
-                                },
-                                {
-                                    'apiGroups': ['authorization.k8s.io'],
-                                    'resources': ['subjectaccessreviews'],
-                                    'verbs': ['create'],
-                                },
-                                {
-                                    'apiGroups': ['kubeflow.org'],
-                                    'resources': [
-                                        'notebooks',
-                                        'notebooks/finalizers',
-                                        'poddefaults',
-                                    ],
-                                    'verbs': ['get', 'list', 'create', 'delete', 'patch', 'update'],
-                                },
-                                {
-                                    'apiGroups': [''],
-                                    'resources': ['persistentvolumeclaims'],
-                                    'verbs': ['create', 'delete', 'get', 'list'],
-                                },
-                                {
-                                    'apiGroups': [''],
-                                    'resources': ['events', 'nodes'],
-                                    'verbs': ['list'],
-                                },
-                                {
-                                    'apiGroups': ['storage.k8s.io'],
-                                    'resources': ['storageclasses'],
-                                    'verbs': ['get', 'list', 'watch'],
-                                },
-                            ],
-                        }
-                    ]
-                },
-                "containers": [
-                    {
-                        "name": "jupyter-ui",
-                        "imageDetails": image_details,
-                        'ports': [{'name': 'http', 'containerPort': config['port']}],
-                        "envConfig": {
-                            'USERID_HEADER': 'kubeflow-userid',
-                            'USERID_PREFIX': '',
-                            'UI': config['ui'],
-                            'URL_PREFIX': config['url-prefix'],
-                            'DEV_MODE': config['dev-mode'],
-                        },
-                        "volumeConfig": [
+        layer = {
+            "services": {"jupyter-ui": 
                             {
-                                "name": "config",
-                                "mountPath": "/etc/config",
-                                "files": [
-                                    {
-                                        "path": "spawner_ui_config.yaml",
-                                        "content": Path('src/spawner_ui_config.yaml').read_text(),
-                                    }
-                                ],
-                            },
-                        ],
-                    }
-                ],
-            },
-        )
-        self.model.unit.status = ActiveStatus()
+                                "override": "replace", 
+                                "startup": "enabled",
+                                "command": "python3 main.py", 
+                                "environment": {
+                                    'USERID_HEADER': 'kubeflow-userid',
+                                    'USERID_PREFIX': '',
+                                    'UI': config['ui'],
+                                    'URL_PREFIX': config['url-prefix'],
+                                    'DEV_MODE': config['dev-mode'],
+                                },
+                            }
+                        },
+                }
+        config_template = None
+        with open(Path('src/spawner_ui_config.yaml')) as file:
+            config_template = yaml.full_load(file)   
+        # Add a Pebble config layer to the scraper container
+        container = self.unit.get_container("jupyter-ui")
+        container.push("/etc/config/spawner_ui_config.yaml", yaml.dump(config_template))
+        container.add_layer("jupyter-ui", layer, combine=True)
+        # Check if the scraper service is already running and start it if not
+        if not container.get_service("jupyter-ui").is_running():
+            container.start("jupyter-ui")
+            logger.info("Jupyter-ui service started")
 
+    def _k8s_auth(self) -> bool:
+        """Authenticate to kubernetes."""
+        if self._authed:
+            return True
+        # Remove os.environ.update when lp:1892255 is FIX_RELEASED.
+        os.environ.update(
+            dict(
+                e.split("=")
+                for e in Path("/proc/1/environ").read_text().split("\x00")
+                if "KUBERNETES_SERVICE" in e
+            )
+        )
+        # Authenticate against the Kubernetes API using a mounted ServiceAccount token
+        kubernetes.config.load_incluster_config()
+        # Test the service account we've got for sufficient perms
+        auth_api = kubernetes.client.RbacAuthorizationV1Api(kubernetes.client.ApiClient())
+
+        try:
+            auth_api.list_cluster_role()
+        except kubernetes.client.exceptions.ApiException as e:
+            if e.status == 403:
+                # If we can't read a cluster role, we don't have enough permissions
+                self.unit.status = BlockedStatus("Run juju trust on this application to continue")
+                return False
+            else:
+                raise e
+
+        self._authed = True
+        return True
 
 if __name__ == "__main__":
-    main(Operator)
+    main(JupyterUICharm)

--- a/charms/jupyter-ui/src/resources.py
+++ b/charms/jupyter-ui/src/resources.py
@@ -1,0 +1,144 @@
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+import logging
+
+from kubernetes import kubernetes
+
+logger = logging.getLogger(__name__)
+
+
+class JupyterUIResources:
+    """Class to handle the creation and deletion of those Kubernetes resources
+    required by the JupyterUI, but not automatically handled by Juju"""
+    def __init__(self, charm):
+        self.model = charm.model
+        self.app = charm.app
+        self.config = charm.config
+        # Setup some Kubernetes API clients we'll need
+        kcl = kubernetes.client.ApiClient()
+        self.apps_api = kubernetes.client.AppsV1Api(kcl)
+        self.core_api = kubernetes.client.CoreV1Api(kcl)
+        self.auth_api = kubernetes.client.RbacAuthorizationV1Api(kcl)
+    
+    
+    def apply(self) -> None:
+        """Create the required Kubernetes resources for the dashboard"""
+        # Create Kubernetes Cluster Roles
+        for cr in self._clusterroles:
+            r = self.auth_api.list_cluster_role(
+                field_selector=f"metadata.name={cr['body'].metadata.name}",
+            )
+            if not r.items:
+                self.auth_api.create_cluster_role(**cr)
+            else:
+                logger.info("cluster role '%s' exists, patching", cr["body"].metadata.name)
+                self.auth_api.patch_cluster_role(name=cr["body"].metadata.name, **cr)
+        # Create Kubernetes Services
+        for service in self._services:
+            s = self.core_api.list_namespaced_service(
+                namespace=service["namespace"],
+                field_selector=f"metadata.name={service['body'].metadata.name}",
+            )
+            if not s.items:
+                self.core_api.create_namespaced_service(**service)
+            else:
+                logger.info(
+                    "service '%s' in namespace '%s' exists, patching",
+                    service["body"].metadata.name,
+                    service["namespace"],
+                )
+                self.core_api.patch_namespaced_service(
+                    name=service["body"].metadata.name, **service
+                )
+
+    def delete(self) -> None:
+        """Delete all of the Kubernetes resources created by the apply method"""
+        # Delete Kubernetes cluster roles
+        for cr in self._clusterroles:
+            self.auth_api.delete_cluster_role(name=cr["body"].metadata.name)
+         # Delete Kubernetes services
+        for service in self._services:
+            self.core_api.delete_namespaced_service(
+                namespace=service["namespace"], name=service["body"].metadata.name
+            )
+    
+    
+    @property
+    def _clusterroles(self) -> list:
+        """Return a list of Cluster Roles required by the Jupyter UI"""
+        return [
+            {
+                "body": kubernetes.client.V1ClusterRole(
+                    api_version="rbac.authorization.k8s.io/v1",
+                    metadata=kubernetes.client.V1ObjectMeta(
+                        name="jupyter-jupyter-ui",
+                        labels={"app.kubernetes.io/name": self.app.name},
+                    ),
+                    rules=[
+                        # Allow Metrics Scraper to get metrics from the Metrics server
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=[""],
+                            resources=["namespaces"],
+                            verbs=["get", "list", "create", "delete"],
+                        ),
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=["authorization.k8s.io"],
+                            resources=["subjectaccessreviews"],
+                            verbs=["create"],
+                        ),
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=["kubeflow.org"],
+                            resources=["notebooks", "notebooks/finalizers", "poddefaults"],
+                            verbs=['get', 'list', 'create', 'delete', 'patch', 'update'],
+                        ),
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=[""],
+                            resources=["persistentvolumeclaims"],
+                            verbs=['create', 'delete', 'get', 'list'],
+                        ),
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=[""],
+                            resources=['events', 'nodes'],
+                            verbs=['list'],
+                        ),
+                        kubernetes.client.V1PolicyRule(
+                            api_groups=['storage.k8s.io'],
+                            resources=['storageclasses'],
+                            verbs=['get', 'list', 'watch'],
+                        ),
+
+                    ],
+                )
+            }
+        ]
+    
+    @property
+    def _services(self) -> list:
+        """Return a list of Kubernetes services needed by the Jupyter UI"""
+        # Note that this service is actually created by Juju, we are patching
+        # it here to include the correct port mapping
+        # TODO: Update when support improves in Juju
+
+        return [
+            {
+                "namespace": self.model.name,
+                "body": kubernetes.client.V1Service(
+                    api_version="v1",
+                    metadata=kubernetes.client.V1ObjectMeta(
+                        namespace=self.model.name,
+                        name=self.app.name,
+                        labels={"app.kubernetes.io/name": self.app.name},
+                    ),
+                    spec=kubernetes.client.V1ServiceSpec(
+                        ports=[
+                            kubernetes.client.V1ServicePort(
+                                name="http",
+                                port=self.config['port'],
+                                target_port=self.config['port'],
+                            )
+                        ],
+                        selector={"app.kubernetes.io/name": self.app.name},
+                    ),
+                ),
+            }
+        ]

--- a/charms/jupyter-ui/src/resources.py
+++ b/charms/jupyter-ui/src/resources.py
@@ -142,3 +142,4 @@ class JupyterUIResources:
                 ),
             }
         ]
+


### PR DESCRIPTION
Hello team,

This is my proposition to convert jupyter-ui to sidecar charm.
One of the issues I found is that, I was not able to launch tensorflow notebooks 1.15 versions. Only 2.1 version works.
Also, I made the default list customazable in the charm. The provider will be able to provide custom notebook images to his users through the charm. It can also be used when we want to add Kale as default image.