### PR TITLE
add default access to pipelines from notebook

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   unit:

--- a/README.md
+++ b/README.md
@@ -27,3 +27,20 @@ with:
 For more information, see https://juju.is/docs
 
 [integrate]: .github/workflows/integrate.yaml
+
+
+## Running the Tests
+
+To run tests for this repo:
+
+1. Install non-python test prerequisites
+```bash
+sudo apt install -y firefox-geckodriver
+sudo snap install juju-bundle --classic
+sudo snap install juju-wait --classic
+
+```
+2. Execute tests in the `kubeflow` model:
+```bash
+tox -e integration -- --model kubeflow
+```

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -17,18 +17,15 @@ applications:
     scale: 1
   istio-pilot:
     charm: ch:istio-pilot
-    channel: latest/edge
+    channel: 1.5/edge
     scale: 1
-    trust: true
     options:
-      default-gateways: kubeflow-gateway
+      default-gateway: kubeflow-gateway
   istio-ingressgateway-operator:
     charm: ch:istio-gateway
-    channel: latest/edge
+    channel: 1.5/edge
     scale: 1
     trust: true
-    options:
-      kind: ingress
   admission-webhook:
     charm: ch:admission-webhook
     channel: latest/edge

--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -211,5 +211,11 @@ spawnerFormDefaults:
     # value:
     #   - add-gcp-secret
     #   - default-editor
-    value: []
+    value:
+    # Added from https://github.com/kubeflow/kubeflow/pull/6160 to fix
+    # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
+    # upstream and if they go with something different we should consider syncing with
+    # upstream.
+    # Auto-selects "Allow access to Kubeflow Pipelines" button in Notebook spawner UI
+    - access-ml-pipeline
     readOnly: false

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 black==20.8b1
 flake8<4.1
 juju<2.10
+lightkube<0.11
 pytest-operator<0.10
 pytest<6.3
 pyyaml<6.1


### PR DESCRIPTION
This is part of the fix for https://github.com/canonical/bundle-kubeflow/issues/423.

This change automatically selects the "Allow access to Kubeflow Pipelines" PodDefault configuration for new notebooks, provided it has been already been added to the user's namespace.  Adding the PodDefault is handled separately.

![image](https://user-images.githubusercontent.com/48125859/151572744-1a891a22-7eb0-4fe0-903e-8cecdaef165d.png)

# Test instructions

See the updated README.md file