### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -1,6 +1,7 @@
 name: jupyter-controller
 summary: Multi-user server for Jupyter notebooks
 description: Multi-user server for Jupyter notebooks
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -1,6 +1,7 @@
 name: jupyter-ui
 summary: Multi-user server for Jupyter notebooks
 description: Multi-user server for Jupyter notebooks
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.
