### PR TITLE
Update observability integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 __pycache__
 .tox
 .coverage
+geckodriver.log

--- a/charms/jupyter-controller/config.yaml
+++ b/charms/jupyter-controller/config.yaml
@@ -7,15 +7,3 @@ options:
     type: boolean
     default: false
     description: Manually enable Istio integration, instead of via relations
-  metrics-port:
-    type: string
-    default: '8080'
-    description: Metrics port
-  metrics-api:
-    type: string
-    default: '/metrics'
-    description: metrics api route
-  metrics-scrape-interval:
-    type: string
-    default: '30s'
-    description: how often metrics are scraped

--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -12,7 +12,7 @@ deployment:
   type: stateless
   service: omit
 provides:
-  monitoring:
+  metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:
     interface: grafana_dashboard

--- a/charms/jupyter-controller/src/charm.py
+++ b/charms/jupyter-controller/src/charm.py
@@ -16,6 +16,9 @@ from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 
+METRICS_PORT = "8080"
+METRICS_PATH = "/metrics"
+
 
 class CheckFailedError(Exception):
     """Raise this exception if one of the checks in main fails."""
@@ -43,13 +46,11 @@ class Operator(CharmBase):
 
         self.prometheus_provider = MetricsEndpointProvider(
             charm=self,
-            relation_name="monitoring",
             jobs=[
                 {
                     "job_name": "jupyter_controller_metrics",
-                    "scrape_interval": self.config["metrics-scrape-interval"],
-                    "metrics_path": self.config["metrics-api"],
-                    "static_configs": [{"targets": ["*:{}".format(self.config["metrics-port"])]}],
+                    "metrics_path": METRICS_PATH,
+                    "static_configs": [{"targets": ["*:{}".format(METRICS_PORT)]}],
                 }
             ],
         )
@@ -61,9 +62,6 @@ class Operator(CharmBase):
             self.on.leader_elected,
             self.on.upgrade_charm,
             self.on.config_changed,
-            self.on["monitoring"].relation_changed,
-            self.on["monitoring"].relation_broken,
-            self.on["monitoring"].relation_departed,
         ]:
             self.framework.observe(event, self.main)
 

--- a/charms/jupyter-controller/src/prometheus_alert_rules/tempfile
+++ b/charms/jupyter-controller/src/prometheus_alert_rules/tempfile
@@ -1,5 +1,0 @@
-"""prometheus_alert_rules folder is only added to .charm file 
-if there is any relevant content.
-Adding this file only to ensure the folder is added to the
-charm and MetricsEndpointProvider does not complain.
-"""

--- a/charms/jupyter-controller/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/charms/jupyter-controller/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,0 +1,10 @@
+alert: JupyterControllerUnitIsUnavailable
+expr: up < 1
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Jupyter controller unit {{ $labels.juju_model }}/{{ $labels.juju_unit }} unavailable
+  description: >
+    The Jupyter controller unit {{ $labels.juju_model }} {{ $labels.juju_unit }} is unavailable
+    LABELS = {{ $labels }}

--- a/charms/jupyter-controller/test-requirements.txt
+++ b/charms/jupyter-controller/test-requirements.txt
@@ -1,3 +1,0 @@
-pytest<6.3
-black==20.8b1
-flake8<4.1

--- a/charms/jupyter-controller/tox.ini
+++ b/charms/jupyter-controller/tox.ini
@@ -67,6 +67,5 @@ deps =
     juju
     pytest-operator
     -r{toxinidir}/requirements.txt 
-    -r{toxinidir}/test-requirements.txt
 commands =
     pytest -v --tb native --asyncio-mode=auto --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -16,7 +16,7 @@ from serialized_data_interface import (
 
 
 class CheckFailed(Exception):
-    """ Raise this exception if one of the checks in main fails. """
+    """Raise this exception if one of the checks in main fails."""
 
     def __init__(self, msg, status_type=None):
         super().__init__()

--- a/charms/jupyter-ui/test-requirements.txt
+++ b/charms/jupyter-ui/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest<6.3
-black==20.8b1
+black
 flake8<4.1

--- a/charms/jupyter-ui/tox.ini
+++ b/charms/jupyter-ui/tox.ini
@@ -18,4 +18,4 @@ commands =
 [testenv:lint]
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
-    black --check {toxinidir}/src {toxinidir}/tests
+    black --check --diff {toxinidir}/src {toxinidir}/tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black
 flake8<4.1
 juju<2.10
 lightkube<0.11

--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -222,12 +222,16 @@ def test_notebook(driver, ops_test, dummy_resources_for_testing):
 async def test_integrate_with_prometheus_and_grafana(ops_test):
     prometheus = "prometheus-k8s"
     grafana = "grafana-k8s"
+    prometheus_scrape = "prometheus-scrape-config-k8s"
     jupyter_controller = "jupyter-controller"
+    scrape_config = {"scrape_interval": "30s"}
     await ops_test.model.deploy(prometheus, channel="latest/beta")
     await ops_test.model.deploy(grafana, channel="latest/beta")
+    await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
+    await ops_test.model.add_relation(jupyter_controller, prometheus_scrape)
+    await ops_test.model.add_relation(prometheus, prometheus_scrape)
     await ops_test.model.add_relation(prometheus, grafana)
     await ops_test.model.add_relation(jupyter_controller, grafana)
-    await ops_test.model.add_relation(prometheus, jupyter_controller)
 
     await ops_test.model.wait_for_idle([jupyter_controller, prometheus, grafana], status="active")
     status = await ops_test.model.get_status()

--- a/tox.ini
+++ b/tox.ini
@@ -22,4 +22,4 @@ passenv =
   DISPLAY
 deps =
   -rtest-requirements.txt
-commands = pytest -vvs --tb native --show-capture=no --log-cli-level=INFO {posargs} {toxinidir}/tests/
+commands = pytest -vvs --tb native --show-capture=no --log-cli-level=INFO --asyncio-mode=auto {posargs} {toxinidir}/tests/


### PR DESCRIPTION
Observability updates:
- rename interfaces
- use scrape charm
- hard code metrics config
- add basic alert rule
- add test
- updated bundle integration test
  - the `test_notebook` test is flaky due to an [upstream bug](https://github.com/kubeflow/kubeflow/issues/6056) with jupyter-ui displaying the created notebook server status. Jupyter ui would sometimes incorrectly display the notebook server status as pending when it is created successfully with no issues.This test is now commented out. `test_create_notebook` test is added to cover the notebook creation part of `test_notebook` test.

Others:
- remove controller's test-requirements.txt as all deps needed are already listed for each env
- update other test-requirements.txt to use latest black