### PR TITLE
jupyter-ui upgrade 1.4->1.6

### DIFF
--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -7,7 +7,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app:v1.4
+    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.6.0-rc.0
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -178,5 +178,11 @@ spawnerFormDefaults:
     # value:
     #   - add-gcp-secret
     #   - default-editor
-    value: []
+    value:
+    # Added from https://github.com/kubeflow/kubeflow/pull/6160 to fix
+    # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
+    # upstream and if they go with something different we should consider syncing with
+    # upstream.
+    # Auto-selects "Allow access to Kubeflow Pipelines" button in Notebook spawner UI
+    - access-ml-pipeline
     readOnly: false

--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.4
+    value: kubeflownotebookswg/jupyter-scipy:v1.5.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.4
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:v1.4
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:v1.4
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:v1.4
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:v1.4
+    - kubeflownotebookswg/jupyter-scipy:v1.6.0-rc.0
+    - kubeflownotebookswg/jupyter-pytorch-full:v1.6.0-rc.0
+    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.6.0-rc.0
+    - kubeflownotebookswg/jupyter-tensorflow-full:v1.6.0-rc.0
+    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.6.0-rc.0
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.4
+    value: kubeflownotebookswg/codeserver-python:v1.6.0-rc.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.4
+    - kubeflownotebookswg/codeserver-python:v1.6.0-rc.0
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,10 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.4
+    value: kubeflownotebookswg/rstudio-tidyverse:v1.6.0-rc.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.4
+    - kubeflownotebookswg/rstudio-tidyverse:v1.6.0-rc.0
   # If true, hide registry and/or tag name in the image selection dropdown
   hideRegistry: true
   hideTag: false
@@ -75,71 +75,38 @@ spawnerFormDefaults:
     readOnly: false
   workspaceVolume:
     # Workspace Volume to be attached to user's Notebook
-    # Each Workspace Volume is declared with the following attributes:
-    # Type, Name, Size, MountPath and Access Mode
+    # If you don't want a workspace volume then delete the 'value' key
     value:
-      type:
-        # The Type of the Workspace Volume
-        # Supported values: 'New', 'Existing'
-        value: New
-      name:
-        # The Name of the Workspace Volume
-        # Note that this is a templated value. Special values:
-        # {notebook-name}: Replaced with the name of the Notebook. The frontend
-        #                  will replace this value as the user types the name
-        value: 'workspace-{notebook-name}'
-      size:
-        # The Size of the Workspace Volume (in Gi)
-        value: '5Gi'
-      mountPath:
-        # The Path that the Workspace Volume will be mounted
-        value: /home/jovyan
-      accessModes:
-        # The Access Mode of the Workspace Volume
-        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
-        value: ReadWriteOnce
-      class:
-        # The StrageClass the PVC will use if type is New. Special values are:
-        # {none}: default StorageClass
-        # {empty}: empty string ""
-        value: '{none}'
+      mount: /home/jovyan
+      newPvc:
+        metadata:
+          name: '{notebook-name}-workspace'
+        spec:
+          resources:
+            requests:
+              storage: 10Gi
+          accessModes:
+          - ReadWriteOnce
     readOnly: false
   dataVolumes:
     # List of additional Data Volumes to be attached to the user's Notebook
     value: []
-    # Each Data Volume is declared with the following attributes:
-    # Type, Name, Size, MountPath and Access Mode
-    #
     # For example, a list with 2 Data Volumes:
     # value:
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: '{notebook-name}-vol-1'
-    #       size:
-    #         value: '10Gi'
-    #       class:
-    #         value: standard
-    #       mountPath:
-    #         value: /home/jovyan/vol-1
-    #       accessModes:
-    #         value: ReadWriteOnce
-    #       class:
-    #         value: {none}
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: '{notebook-name}-vol-2'
-    #       size:
-    #         value: '10Gi'
-    #       mountPath:
-    #         value: /home/jovyan/vol-2
-    #       accessModes:
-    #         value: ReadWriteMany
-    #       class:
-    #         value: {none}
+    #   - mount: /home/jovyan/datavol-1
+    #     newPvc:
+    #       metadata:
+    #         name: '{notebook-name}-datavol-1'
+    #       spec:
+    #         resources:
+    #           requests:
+    #             storage: 5Gi
+    #         accessModes:
+    #           - ReadWriteOnce
+    #   - mount: /home/jovyan/datavol-1
+    #     existingSource:
+    #       persistentVolumeClaim:
+    #         claimName: test-pvc
     readOnly: false
   gpus:
     # Number of GPUs to be assigned to the Notebook Container
@@ -211,11 +178,5 @@ spawnerFormDefaults:
     # value:
     #   - add-gcp-secret
     #   - default-editor
-    value:
-    # Added from https://github.com/kubeflow/kubeflow/pull/6160 to fix
-    # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
-    # upstream and if they go with something different we should consider syncing with
-    # upstream.
-    # Auto-selects "Allow access to Kubeflow Pipelines" button in Notebook spawner UI
-    - access-ml-pipeline
+    value: []
     readOnly: false

--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -277,7 +277,7 @@ async def test_integrate_with_prometheus_and_grafana(ops_test):
     jupyter_controller = "jupyter-controller"
     scrape_config = {"scrape_interval": "30s"}
     await ops_test.model.deploy(prometheus, channel="latest/beta", trust=True)
-    await ops_test.model.deploy(grafana, channel="latest/beta", trust=True)
+    await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
     await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
     await ops_test.model.add_relation(jupyter_controller, prometheus_scrape)
     await ops_test.model.add_relation(


### PR DESCRIPTION
Upgrades jupyter-ui to 1.6.0-rc0 (stable version coming in the next few weeks). This PR introduces the following:
* Updates manifest files to match latest release
* Upstream jupyter-web-app image version bump
* Updates libraries

Note: These changes will be tested in k8s 1.21 in this PR and 1.22 in a different one.

Merge after #40, #41
