### PR TITLE
tests: updates bundle integration tests to match notebook-operator upgrades

### DIFF
--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -122,7 +122,7 @@ def driver(request, ops_test, lightkube_client):
     this_namespace = ops_test.model_name
 
     ingress_service = lightkube_client.get(
-        res=Service, name=INGRESSGATEWAY_NAME, namespace=this_namespace
+        res=Service, name=f"{INGRESSGATEWAY_NAME}-workload", namespace=this_namespace
     )
     gateway_ip = ingress_service.status.loadBalancer.ingress[0].ip
 

--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -30,6 +30,7 @@ UI_APP_NAME = UI_METADATA["name"]
 
 
 INGRESSGATEWAY_NAME = "istio-ingressgateway"
+PROFILE_NAME = "kubeflow-user"
 
 
 @pytest.fixture(scope="module")
@@ -106,7 +107,7 @@ async def test_build_and_deploy(ops_test, lightkube_client, dummy_resources_for_
     await ops_test.model.deploy(controller_charm, resources={"oci-image": controller_image_path})
     await ops_test.model.deploy("admission-webhook", channel="latest/edge")
     await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge")
-    await ops_test.model.deploy("kubeflow-dashboard", channel="latest/edge")
+    await ops_test.model.deploy("kubeflow-dashboard", channel="latest/edge", config={"profile": PROFILE_NAME})
     await ops_test.model.add_relation("kubeflow-profiles", "kubeflow-dashboard")
 
     # Wait for everything to deploy


### PR DESCRIPTION
Updates bundle integration tests with:
*    latest/edge istio, admission-webhook, kubeflow-profies,
      kubeflow-dashboard
* Removes patch_ingressgateway (and related) as it is not needed
      for istio 1.11
* Re-orders the way deps and the notebook channels are deployed
* latest/edge kubeflow-dashboard and configurations