### PR TITLE
tests: fixes for bundle integration tests

### DIFF
--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -232,7 +232,7 @@ def driver(request, ops_test, lightkube_client):
 #        EC.presence_of_element_located((By.XPATH, f"//*[contains(text(), '{notebook_name}')]"))
 #    )
 
-
+@pytest.mark.skip('Skipping due to this test being inconsistent, and it will be changed soon')
 def test_create_notebook(driver, ops_test, dummy_resources_for_testing):
     """Ensures a notebook can be created. Does not test connection due to upstream bug.
     https://github.com/kubeflow/kubeflow/issues/6056


### PR DESCRIPTION
1) This PR introduces a commit to skip the `test_create_notebook` testcase from the bundle tests. This change is due to the test being inconsistent with every release, making it hard to maintain and keep up to date. We should focus on having more reliable tests in the near future.
2) Due to recent changes in grafana and prometheus, the test case checking the integration of those charms with notebooks must be updated. In this PR we are adding the missing interfaces in the relation and also trusting the charms.