### PR TITLE
chore: oci image version bump 1.6.0-rc.2 -> 1.6.0

### DIFF
--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -7,7 +7,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/notebook-controller:v1.6.0-rc.2
+    upstream-source: docker.io/kubeflownotebookswg/notebook-controller:v1.6.0
 deployment:
   type: stateless
   service: omit

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -7,7 +7,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.6.0-rc.2
+    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.6.0
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: kubeflownotebookswg/jupyter-scipy:v1.6.0-rc.2
+    value: kubeflownotebookswg/jupyter-scipy:v1.6.0
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/jupyter-scipy:v1.6.0-rc.2
-    - kubeflownotebookswg/jupyter-pytorch-full:v1.6.0-rc.2
-    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.6.0-rc.2
-    - kubeflownotebookswg/jupyter-tensorflow-full:v1.6.0-rc.2
-    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.6.0-rc.2
+    - kubeflownotebookswg/jupyter-scipy:v1.6.0
+    - kubeflownotebookswg/jupyter-pytorch-full:v1.6.0
+    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.6.0
+    - kubeflownotebookswg/jupyter-tensorflow-full:v1.6.0
+    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.6.0
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: kubeflownotebookswg/codeserver-python:v1.6.0-rc.2
+    value: kubeflownotebookswg/codeserver-python:v1.6.0
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/codeserver-python:v1.6.0-rc.2
+    - kubeflownotebookswg/codeserver-python:v1.6.0
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,10 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: kubeflownotebookswg/rstudio-tidyverse:v1.6.0-rc.2
+    value: kubeflownotebookswg/rstudio-tidyverse:v1.6.0
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/rstudio-tidyverse:v1.6.0-rc.2
+    - kubeflownotebookswg/rstudio-tidyverse:v1.6.0
   # If true, hide registry and/or tag name in the image selection dropdown
   hideRegistry: true
   hideTag: false


### PR DESCRIPTION
Version bump to 1.6.0 release image

NOTE: this PR depends on the latest image tag specified in [kubeflow/manifests](https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/admission-webhook/upstream