### PR TITLE
build: unpin ops to use latest

### DIFF
--- a/charms/jupyter-controller/requirements.txt
+++ b/charms/jupyter-controller/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.3.0
+ops
 oci-image==1.0.0

--- a/charms/jupyter-ui/requirements.txt
+++ b/charms/jupyter-ui/requirements.txt
@@ -1,3 +1,3 @@
-ops==1.2.0
+ops
 oci-image==1.0.0
 serialized-data-interface<0.4


### PR DESCRIPTION
Install latest ops to avoid CI issues.

NOTE: tests are expected to fail, fixes are tracked in #68 and #69 