### PR TITLE
ci: microk8s version bump 1.21->1.22 (DO NOT MERGE - OBSOLETED)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -81,7 +81,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.21/stable
+        channel: 1.22/stable
         # Pinned to 2.3.34 due to https://bugs.launchpad.net/juju/+bug/1992833
         # This should be fixed on release of juju 2.3.36 + libjuju 3.0.3
         bootstrap-options: --agent-version="2.9.34"


### PR DESCRIPTION
There was a missing microk8s version that needed a bump.