### PR TITLE
fix: add ignore path to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,5 +44,6 @@
             ],
             "automerge": true
         }
-    ]
+    ],
+    "ignorePaths": ["**/image-definitions/**"]
 }


### PR DESCRIPTION
Summary of chnages:
- Added ignorePath to Renovate to exclude images-definitions.