### PR TITLE
[KF-1471] fix: add default value for pipelines (#221)

### DIFF
--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -180,5 +180,11 @@ spawnerFormDefaults:
     # value:
     #   - add-gcp-secret
     #   - default-editor
-    value: []
+    value:
+    # Added from https://github.com/kubeflow/kubeflow/pull/6160 to fix
+    # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
+    # upstream and if they go with something different we should consider syncing with
+    # upstream.
+    # Auto-selects "Allow access to Kubeflow Pipelines" button in Notebook spawner UI
+    - access-ml-pipeline
     readOnly: false

--- a/charms/jupyter-ui/tests/unit/test_operator.py
+++ b/charms/jupyter-ui/tests/unit/test_operator.py
@@ -4,6 +4,7 @@
 
 """Unit tests for JupyterUI Charm."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,6 +28,27 @@ def harness() -> Harness:
 
 class TestCharm:
     """Test class for JupyterUI."""
+
+    def test_spawner_ui(self):
+        """Test spawner UI.
+
+        spawner_ui_config.yaml contains a number of changes that were done for Charmed
+        Kubeflow. This test is to validate those. If it fails, spawner_ui_config.yaml
+        should be reviewed and changes to this tests should be made, if required.
+        """
+        spawner_ui_config = yaml.safe_load(Path("./src/spawner_ui_config.yaml").read_text())
+
+        # test for default configurations
+        # only single configuration value is currently set in the list of values
+        config_value = spawner_ui_config["spawnerFormDefaults"]["configurations"]["value"]
+        assert config_value == ["access-ml-pipeline"]
+
+        # test for images added in addition to upstream
+        image_list = spawner_ui_config["spawnerFormDefaults"]["image"]["options"]
+        assert any(
+            "swr.cn-south-1.myhuaweicloud.com/mindspore/jupyter-mindspore" in image
+            for image in image_list
+        )
 
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
     @patch("charm.JupyterUI.k8s_resource_handler")


### PR DESCRIPTION
* fix: add default value for pipelines https://github.com/canonical/kfp-operators/issues/159

Fixes #159 

Summary of changes:
- Added back default value for pipelines access.
- Added tests for default values of pipelines access and images for 1.7 release.
- Modified code to check for mindspore image only not version.

---------