### PR TITLE
feat: get all images managed by workload

### DIFF
--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+)
+# dynamic list
+# TO-DO uncomment for production
+#git checkout origin/track/1.7
+IMAGE_LIST=()
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .image | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupOne | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupTwo | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -6,8 +6,7 @@
 STATIC_IMAGE_LIST=(
 )
 # dynamic list
-# TO-DO uncomment for production
-#git checkout origin/track/1.7
+git checkout origin/track/1.7
 IMAGE_LIST=()
 IMAGE_LIST+=($(yq '.spawnerFormDefaults | .image | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
 IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupOne | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))

--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -6,11 +6,12 @@
 STATIC_IMAGE_LIST=(
 )
 # dynamic list
-git checkout origin/track/1.7
+#git checkout origin/track/1.7
 IMAGE_LIST=()
-IMAGE_LIST+=($(yq '.spawnerFormDefaults | .image | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
-IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupOne | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
-IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupTwo | .options | values[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+IMAGE_LIST+=($(find $REPO -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .image | .options | .[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupOne | .options | .[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
+IMAGE_LIST+=($(yq '.spawnerFormDefaults | .imageGroupTwo | .options | .[]' charms/jupyter-ui/src/spawner_ui_config.yaml))
 
 printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Script that produces list of all workload managed container images that are related to this charm's workload.