### PR TITLE
fix: pin python-libjuju<3.0

### DIFF
--- a/charms/jupyter-ui/requirements-integration.in
+++ b/charms/jupyter-ui/requirements-integration.in
@@ -1,6 +1,6 @@
 aiohttp
 jinja2
-juju<3.1
+juju<3.0
 pytest-operator
 requests
 tenacity

--- a/charms/jupyter-ui/requirements-integration.txt
+++ b/charms/jupyter-ui/requirements-integration.txt
@@ -104,7 +104,7 @@ jsonschema==3.2.0
     # via
     #   -r requirements.txt
     #   serialized-data-interface
-juju==3.0.4
+juju==2.9.43.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator


### PR DESCRIPTION
`juju~3` is a transitional version that is no longer supported.  We should use `juju<3` until we are using `Juju` 3.1+
