### PR TITLE
feat: move aggregation ClusterRoles to charms

### DIFF
--- a/charms/jupyter-controller/src/templates/auth_manifests.yaml.j2
+++ b/charms/jupyter-controller/src/templates/auth_manifests.yaml.j2
@@ -59,3 +59,56 @@ subjects:
 - kind: ServiceAccount
   name: {{ app_name }}
   namespace: {{ namespace }}
+---
+# manifests/apps/jupyter/notebook-controller/upstream/rbac/user_cluster_roles.yaml
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: notebook-controller-kubeflow-notebooks-admin
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+  name: notebook-controller-kubeflow-notebooks-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: notebook-controller-kubeflow-notebooks-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/charms/jupyter-controller/src/templates/auth_manifests.yaml.j2
+++ b/charms/jupyter-controller/src/templates/auth_manifests.yaml.j2
@@ -71,7 +71,8 @@ metadata:
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin
-rules: []
+# Commenting out rules: [] due to https://github.com/gtsystem/lightkube/issues/32
+# rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charms/jupyter-ui/src/templates/auth_manifests.yaml.j2
+++ b/charms/jupyter-ui/src/templates/auth_manifests.yaml.j2
@@ -77,3 +77,62 @@ subjects:
 - kind: ServiceAccount
   name: {{ app_name }}
   namespace: {{ namespace }}
+---
+# Source: manifests/apps/jupyter/jupyter-web-app/upstream/base/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-admin
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/charms/jupyter-ui/src/templates/auth_manifests.yaml.j2
+++ b/charms/jupyter-ui/src/templates/auth_manifests.yaml.j2
@@ -87,7 +87,8 @@ metadata:
     kustomize.component: jupyter-web-app
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: jupyter-web-app-kubeflow-notebook-ui-admin
-rules: []
+# Commenting out rules: [] due to https://github.com/gtsystem/lightkube/issues/32
+#rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Summary of changes:
`jupyter-controller` and `jupyter-ui` charms are sidecar charms that can create their own aggregation ClusterRoles
This moves the aggregation ClusterRoles from https://github.com/canonical/kubeflow-roles-operator/tree/main/src/manifests to its own charm.

PR in `kubeflow-roles-operator` to remove those same roles from the kubeflow-roles charm https://github.com/canonical/kubeflow-roles-operator/pull/71