### PR TITLE
feat: port jupyter notebook rocks to 1.7

### DIFF
--- a/charms/jupyter-ui/src/spawner_ui_config.yaml
+++ b/charms/jupyter-ui/src/spawner_ui_config.yaml
@@ -18,14 +18,14 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: kubeflownotebookswg/jupyter-scipy:v1.7.0
+    value: charmedkubeflow/jupyter-scipy:v1.7.0_20.04_1
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/jupyter-scipy:v1.7.0
-    - kubeflownotebookswg/jupyter-pytorch-full:v1.7.0
-    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.7.0
-    - kubeflownotebookswg/jupyter-tensorflow-full:v1.7.0
-    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.7.0
+    - charmedkubeflow/jupyter-scipy:v1.7.0_20.04_1
+    - charmedkubeflow/jupyter-pytorch-full:v1.7.0_20.04_1
+    - charmedkubeflow/jupyter-pytorch-cuda-full:v1.7.0_20.04_1
+    - charmedkubeflow/jupyter-tensorflow-full:v1.7.0_20.04_1
+    - charmedkubeflow/jupyter-tensorflow-cuda-full:v1.7.0_20.04_1
     - swr.cn-south-1.myhuaweicloud.com/mindspore/jupyter-mindspore:v1.6.1
   imageGroupOne:
     # The container Image for the user's Group One Server


### PR DESCRIPTION
# Description

Jupyter Notebook ROCK images need to be integrated into `track/1.7` to provide more secure images.

# Summary of changes:
- Updated spawner UI config with references to published ROCK images.

NOTE: This is cleaned up version of PR #300 