### PR TITLE
update notebook server images to final v1.8.0 release

### DIFF
--- a/charms/jupyter-controller/examples/sample-notebook.yaml
+++ b/charms/jupyter-controller/examples/sample-notebook.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: notebook
-        image: kubeflownotebookswg/jupyter-pytorch-full:v1.8.0-rc.0
+        image: kubeflownotebookswg/jupyter-pytorch-full:v1.8.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/charms/jupyter-ui/config.yaml
+++ b/charms/jupyter-ui/config.yaml
@@ -19,22 +19,25 @@ options:
     type: boolean
     default: false
     description: Whether cookies should require HTTPS
+  # Note: *-images options here are intentionally not in alphabetical order
+  #       in order to match the same order as in the spawner_ui_config.yaml
+  #       (typos have been made in past when the order o)
   jupyter-images:
     type: string
     default: |
-      - kubeflownotebookswg/jupyter-scipy:v1.8.0-rc.0
-      - kubeflownotebookswg/jupyter-pytorch-full:v1.8.0-rc.0
-      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0-rc.0
-      - kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0-rc.0
-      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0-rc.0
+      - kubeflownotebookswg/jupyter-scipy:v1.8.0
+      - kubeflownotebookswg/jupyter-pytorch-full:v1.8.0
+      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0
+      - kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0
+      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0
     description: list of image options for Jupyter Notebook
-  rstudio-images:
-    type: string
-    default: |
-      - kubeflownotebookswg/codeserver-python:v1.8.0-rc.0
-    description: list of image options for RStudio
   vscode-images:
     type: string
     default: |
-      - kubeflownotebookswg/rstudio-tidyverse:v1.8.0-rc.0
+      - kubeflownotebookswg/codeserver-python:v1.8.0
     description: list of image options for VSCode
+  rstudio-images:
+    type: string
+    default: |
+      - kubeflownotebookswg/rstudio-tidyverse:v1.8.0
+    description: list of image options for RStudio


### PR DESCRIPTION
Removes the `-rc*` from all notebook images, pointing instead to the final releases.

Also fixes a bug where, previously, the vscode and rstudio images were reversed in config.yaml (the vscode-images entry had an rstudio image, and vise versa).  This may have been because the config.yaml images are in a different order than the upstream spawner_ui_config.yaml that we sync to - to avoid this in future, the config.yaml ordering was changed.
