### PR TITLE
Use use-istio config in charm.py

### DIFF
--- a/charms/jupyter-controller/config.yaml
+++ b/charms/jupyter-controller/config.yaml
@@ -5,5 +5,5 @@ options:
     description: Enables culling of idle Jupyter pods
   use-istio:
     type: boolean
-    default: false
+    default: true
     description: Manually enable Istio integration, instead of via relations

--- a/charms/jupyter-controller/src/charm.py
+++ b/charms/jupyter-controller/src/charm.py
@@ -127,7 +127,7 @@ class JupyterController(CharmBase):
         """Return environment variables based on model configuration."""
         config = self.model.config
         ret_env_vars = {
-            "USE_ISTIO": "true",
+            "USE_ISTIO": config["use-istio"],
             "ISTIO_GATEWAY": f"{self.model.name}/kubeflow-gateway",
             "ENABLE_CULLING": config["enable-culling"],
         }


### PR DESCRIPTION
Fix for https://github.com/canonical/notebook-operators/issues/322

We want to use the value from config in the charm.py. Charm should behave the same as before (just a little fix).