### PR TITLE
chore: use the latest JWA image

### DIFF
--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:1.8-816a3b9
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:1.8-816a3b9
+    upstream-source: docker.io/charmedkubeflow/jupyter-web-app:1.8-816a3b9
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -155,7 +155,7 @@ class JupyterUI(CharmBase):
             "description": "Pebble config layer for jupyter-ui",
             "services": {
                 self._container_name: {
-                    "override": "replace",
+                    "override": "merge",
                     "summary": "Entrypoint of jupyter-ui image",
                     "command": self._exec_command,
                     "startup": "enabled",


### PR DESCRIPTION
canonical/kubeflow-rocks#81 introduced changes in the rockcraft project that improved readability and set a standard. This commit uses the version of the container image that corresponds to that PR.