### PR TITLE
backport(fix): Grafana dashboard shows data from #344

### DIFF
--- a/charms/jupyter-controller/src/grafana_dashboards/jupyter-notebook-controller.json.tmpl
+++ b/charms/jupyter-controller/src/grafana_dashboards/jupyter-notebook-controller.json.tmpl
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "${prometheusds}",
-        "uid": "P19B9F3F8E2C8F6D0"
-      },
+      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -106,10 +103,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "${prometheusds}",
-            "uid": "P19B9F3F8E2C8F6D0"
-          },
+          "datasource": "${prometheusds}",
           "editorMode": "builder",
           "exemplar": false,
           "expr": "notebook_create_total",
@@ -125,10 +119,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "${prometheusds}",
-        "uid": "P19B9F3F8E2C8F6D0"
-      },
+      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -137,7 +128,7 @@
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "Number of notebools",
+            "axisLabel": "Number of notebooks",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
@@ -201,10 +192,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "${prometheusds}",
-            "uid": "P19B9F3F8E2C8F6D0"
-          },
+          "datasource": "${prometheusds}",
           "editorMode": "builder",
           "expr": "notebook_running",
           "interval": "1",
@@ -219,7 +207,10 @@
   ],
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "ckf",
+    "jupyter"
+  ],
   "templating": {
     "list": []
   },

--- a/charms/jupyter-controller/tests/integration/test_charm.py
+++ b/charms/jupyter-controller/tests/integration/test_charm.py
@@ -68,15 +68,11 @@ async def test_prometheus_integration(ops_test: OpsTest):
     prometheus_scrape = "prometheus-scrape-config-k8s"
     scrape_config = {"scrape_interval": "30s"}
 
-    # Deploy and relate prometheus
-    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
     await ops_test.juju(
         "deploy",
         prometheus,
         "--channel",
         "latest/edge",
-        "--revision",
-        "137",
         "--trust",
         check=True,
     )
@@ -176,9 +172,9 @@ async def test_prometheus_integration(ops_test: OpsTest):
                 assert rule["name"] in test_alerts
 
 
-# Helper to retry calling a function over 30 seconds or 5 attempts
+# Helper to retry calling a function over 30 seconds for 10 attempts
 retry_for_5_attempts = tenacity.Retrying(
-    stop=(tenacity.stop_after_attempt(5) | tenacity.stop_after_delay(30)),
+    stop=(tenacity.stop_after_attempt(10) | tenacity.stop_after_delay(30)),
     wait=tenacity.wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,
 )


### PR DESCRIPTION
Backport the following:
* Remove `uid` from the `datasource` fields.
* fix typo
* Add tag `ckf` to dashboard.
* Increase retry_for_attempts to 10 attempts
* unpin prometheus

Part of canonical/bundle-kubeflow#856
Ref canonical/bundle-kubeflow#834