### PR TITLE
tests: pin deployed charms to CKF 1.8 compatible versions

### DIFF
--- a/charms/jupyter-controller/tests/integration/test_charm.py
+++ b/charms/jupyter-controller/tests/integration/test_charm.py
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 JUPYTER_UI = "jupyter-ui"
+JUPYTER_UI_CHANNEL = "1.8/stable"
 JUPYTER_UI_TRUST = True
 
 ISTIO_OPERATORS_CHANNEL = "1.17/stable"
@@ -72,7 +73,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         timeout=300,
     )
     # Deploy jupyter-ui and relate to istio
-    await ops_test.model.deploy(JUPYTER_UI, trust=JUPYTER_UI_TRUST)
+    await ops_test.model.deploy(JUPYTER_UI, channel=JUPYTER_UI_CHANNEL, trust=JUPYTER_UI_TRUST)
     await ops_test.model.add_relation(JUPYTER_UI, ISTIO_PILOT)
     await ops_test.model.wait_for_idle(apps=[JUPYTER_UI], status="active", timeout=60 * 15)
 

--- a/charms/jupyter-controller/tests/integration/test_charm.py
+++ b/charms/jupyter-controller/tests/integration/test_charm.py
@@ -75,7 +75,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Deploy jupyter-ui and relate to istio
     await ops_test.model.deploy(JUPYTER_UI, channel=JUPYTER_UI_CHANNEL, trust=JUPYTER_UI_TRUST)
     await ops_test.model.add_relation(JUPYTER_UI, ISTIO_PILOT)
-    await ops_test.model.wait_for_idle(apps=[JUPYTER_UI], status="active", timeout=60 * 15)
 
     my_charm = await ops_test.build_charm(".")
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]

--- a/charms/jupyter-controller/tests/integration/test_charm.py
+++ b/charms/jupyter-controller/tests/integration/test_charm.py
@@ -22,34 +22,65 @@ log = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+UI_PATH = Path("charms/jupyter-ui")
+UI_METADATA = yaml.safe_load(Path(f"{UI_PATH}/metadata.yaml").read_text())
+UI_APP_NAME = UI_METADATA["name"]
+
+ISTIO_OPERATORS_CHANNEL = "1.17/stable"
+ISTIO_PILOT = "istio-pilot"
+ISTIO_PILOT_TRUST = True
+ISTIO_PILOT_CONFIG = {"default-gateway": "kubeflow-gateway"}
+ISTIO_GATEWAY = "istio-gateway"
+ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
+ISTIO_GATEWAY_TRUST = True
+ISTIO_GATEWAY_CONFIG = {"kind": "ingress"}
+
+PROMETHEUS_K8S = "prometheus-k8s"
+PROMETHEUS_K8S_CHANNEL = "1.0/stable"
+PROMETHEUS_K8S_TRUST = True
+PROMETHEUS_SCRAPE_K8S = "prometheus-scrape-config-k8s"
+PROMETHEUS_SCRAPE_K8S_CHANNEL = "1.0/stable"
+PROMETHEUS_SCRAPE_CONFIG = {"scrape_interval": "30s"}
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     """Test build and deploy."""
+    ui_charm = await ops_test.build_charm(UI_PATH)
+    ui_image_path = UI_METADATA["resources"]["oci-image"]["upstream-source"]
+
+    # Deploy istio-operators first
     await ops_test.model.deploy(
-        "istio-pilot",
-        channel="latest/edge",
-        config={"default-gateway": "test-gateway"},
-        trust=True,
+        entity_url=ISTIO_PILOT,
+        channel=ISTIO_OPERATORS_CHANNEL,
+        config=ISTIO_PILOT_CONFIG,
+        trust=ISTIO_PILOT_TRUST,
     )
     await ops_test.model.deploy(
-        "istio-gateway",
-        application_name="istio-ingressgateway",
-        channel="latest/edge",
-        config={"kind": "ingress"},
-        trust=True,
-    )
-    await ops_test.model.add_relation("istio-pilot", "istio-ingressgateway")
-    await ops_test.model.wait_for_idle(
-        ["istio-pilot", "istio-ingressgateway"],
-        raise_on_blocked=False,
-        status="active",
-        timeout=90 * 10,
+        entity_url=ISTIO_GATEWAY,
+        application_name=ISTIO_GATEWAY_APP_NAME,
+        channel=ISTIO_OPERATORS_CHANNEL,
+        config=ISTIO_GATEWAY_CONFIG,
+        trust=ISTIO_GATEWAY_TRUST,
     )
 
-    await ops_test.model.deploy("jupyter-ui", trust=True)
-    await ops_test.model.add_relation("jupyter-ui", "istio-pilot")
+    await ops_test.model.add_relation(
+        ISTIO_PILOT,
+        ISTIO_GATEWAY_APP_NAME,
+    )
+
+    await ops_test.model.wait_for_idle(
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=True,
+        timeout=300,
+    )
+    # Deploy jupyter-ui and relate to istio
+    await ops_test.model.deploy(
+        ui_charm, resources={"oci-image": ui_image_path}, application_name=UI_APP_NAME, trust=True
+    )
+    await ops_test.model.add_relation(UI_APP_NAME, ISTIO_PILOT)
+    await ops_test.model.wait_for_idle(apps=[UI_APP_NAME], status="active", timeout=60 * 15)
 
     my_charm = await ops_test.build_charm(".")
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
@@ -64,29 +95,28 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 async def test_prometheus_integration(ops_test: OpsTest):
     """Deploy prometheus and required relations, then test the metrics."""
-    prometheus = "prometheus-k8s"
-    prometheus_scrape = "prometheus-scrape-config-k8s"
-    scrape_config = {"scrape_interval": "30s"}
-
-    await ops_test.juju(
-        "deploy",
-        prometheus,
-        "--channel",
-        "latest/edge",
-        "--trust",
-        check=True,
+    await ops_test.model.deploy(
+        PROMETHEUS_K8S,
+        channel=PROMETHEUS_K8S_CHANNEL,
+        trust=PROMETHEUS_K8S_TRUST,
     )
-    await ops_test.model.deploy(prometheus_scrape, channel="latest/stable", config=scrape_config)
+    await ops_test.model.deploy(
+        PROMETHEUS_SCRAPE_K8S,
+        channel=PROMETHEUS_SCRAPE_K8S_CHANNEL,
+        config=PROMETHEUS_SCRAPE_CONFIG,
+    )
 
-    await ops_test.model.add_relation(APP_NAME, prometheus_scrape)
+    await ops_test.model.add_relation(APP_NAME, PROMETHEUS_SCRAPE_K8S)
     await ops_test.model.add_relation(
-        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+        f"{PROMETHEUS_K8S}:metrics-endpoint",
+        f"{PROMETHEUS_SCRAPE_K8S}:metrics-endpoint",
     )
 
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 20)
-
     status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]
+    prometheus_unit_ip = status["applications"][PROMETHEUS_K8S]["units"][f"{PROMETHEUS_K8S}/0"][
+        "address"
+    ]
     log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
 
     for attempt in retry_for_5_attempts:


### PR DESCRIPTION
This commit pins all charms that get deployed from Charmhub to a compatible version to the CKF 1.8 release. This commit only affects individual integration tests.

Part of canonical/bundle-kubeflow#863