### PR TITLE
chore: update image tag for jupyter-ui

### DIFF
--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/charmedkubeflow/jupyter-web-app:1.8-816a3b9
+    upstream-source: docker.io/charmedkubeflow/jupyter-web-app:1.8-2605035
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
This commit changes the container image of the `jupyter-ui` charm to jupyter-web-app:1.8-2605035 as this latest version introduced a fix for the entrypoint command.

#### Testing instructions

With the CKF bundle:

1. Deploy the CKF 1.8 bundle
2. Build the charm in this PR and refresh `jupyter-ui` with it
3. Login in the dashboard and confirm the Notebooks page is working correctly by creating a Notebook and interacting with the web app.

With relevant charms:
1. Deploy `istio-operators` from latest/edge
2. Deploy the charm in this PR
3. Relate it to `istio-pilot`
4. Wait for the charm to become active and idle
5. Look into the container logs for any anomalies.