### PR TITLE
chore: use latest JWA image

### DIFF
--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.8.0
+    upstream-source: docker.io/charmedkubeflow/jupyter-web-app:1.8-2605035
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -155,7 +155,7 @@ class JupyterUI(CharmBase):
             "description": "Pebble config layer for jupyter-ui",
             "services": {
                 self._container_name: {
-                    "override": "replace",
+                    "override": "merge",
                     "summary": "Entrypoint of jupyter-ui image",
                     "command": self._exec_command,
                     "startup": "enabled",


### PR DESCRIPTION
canonical/kubeflow-rocks#81 introduced changes in the rockcraft project that improved readability and set a standard. This commit uses the version of the container image that corresponds to that PR.

#### Testing instructions

With the CKF bundle:

1. Deploy the CKF 1.8 bundle
2. Build the charm in this PR and refresh `jupyter-ui` with it
3. Login in the dashboard and confirm the Notebooks page is working correctly by creating a Notebook and interacting with the web app.

With relevant charms:
1. Deploy `istio-operators` from 1.17/stable
2. Deploy the charm in this PR
3. Relate it to `istio-pilot`
4. Wait for the charm to become active and idle
5. Look into the container logs for any anomalies.