### PR TITLE
ci: bootstrap juju controller with agent version 3.5.0 (#374)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -49,6 +49,8 @@ jobs:
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.5/stable
+          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
+          bootstrap-options: "--agent-version=3.5.0"
 
     - run: tox -e ${{ matrix.charm }}-integration
 
@@ -78,6 +80,8 @@ jobs:
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns storage rbac ingress metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.5/stable
+          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
+          bootstrap-options: "--agent-version=3.5.0"
 
     - name: Run test
       run: |


### PR DESCRIPTION
This commit ensures the controller is bootstrapped with version 3.5.0 instead of the default as we have found issues with it.
This is a workaround for canonical/bundle-kubeflow#921.

Fixes #373