### PR TITLE
Integrate notebook-operators rocks

### DIFF
--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/notebook-controller:v1.9.0-rc.0
+    upstream-source: charmedkubeflow/notebook-controller:1.9.0-d701af2
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.9.0-rc.0
+    upstream-source: charmedkubeflow/jupyter-web-app:1.9.0-0fc426a
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes https://github.com/canonical/kubeflow-rocks/issues/99, https://github.com/canonical/kubeflow-rocks/issues/98

I have changed the images for the new rocks. Tested locally by deploying both charms, without problems.