### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -48,9 +48,7 @@ jobs:
           channel: 1.25-strict/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.5/stable
-          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
-          bootstrap-options: "--agent-version=3.5.0"
+          juju-channel: 3.4/stable
 
     - run: tox -e ${{ matrix.charm }}-integration
 
@@ -79,9 +77,7 @@ jobs:
           channel: 1.25-strict/stable
           charmcraft-channel: latest/candidate
           microk8s-addons: "dns storage rbac ingress metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.5/stable
-          # Remove when https://github.com/canonical/bundle-kubeflow/issues/921 is fixed
-          bootstrap-options: "--agent-version=3.5.0"
+          juju-channel: 3.4/stable
 
     - name: Run test
       run: |


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944