### PR TITLE
chore: integrate charmedkubeflow/jupyter-web-app:1.9.0-0fc426a

### DIFF
--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.9.0-rc.0
+    upstream-source: charmedkubeflow/jupyter-web-app:1.9.0-0fc426a
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Use charmedkubeflow/jupyter-web-app:1.9.0-0fc426a as oci-image.

Fixes canonical/kubeflow-rocks#99