### PR TITLE
chore: update manifests for kf v1.9.0

### DIFF
--- a/charms/jupyter-controller/examples/sample-notebook.yaml
+++ b/charms/jupyter-controller/examples/sample-notebook.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: notebook
-        image: kubeflownotebookswg/jupyter-pytorch-full:v1.9.0-rc.0
+        image: kubeflownotebookswg/jupyter-pytorch-full:v1.9.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: charmedkubeflow/notebook-controller:1.9.0-d701af2
+    upstream-source: docker.io/kubeflownotebookswg/notebook-controller:v1.9.0
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/jupyter-ui/config.yaml
+++ b/charms/jupyter-ui/config.yaml
@@ -25,21 +25,21 @@ options:
   jupyter-images:
     type: string
     default: |
-      - kubeflownotebookswg/jupyter-scipy:v1.9.0-rc.0
-      - kubeflownotebookswg/jupyter-pytorch-full:v1.9.0-rc.0
-      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.9.0-rc.0
-      - kubeflownotebookswg/jupyter-tensorflow-full:v1.9.0-rc.0
-      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.9.0-rc.0
+      - kubeflownotebookswg/jupyter-scipy:v1.9.0
+      - kubeflownotebookswg/jupyter-pytorch-full:v1.9.0
+      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.9.0
+      - kubeflownotebookswg/jupyter-tensorflow-full:v1.9.0
+      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.9.0
     description: list of image options for Jupyter Notebook
   vscode-images:
     type: string
     default: |
-      - kubeflownotebookswg/codeserver-python:v1.9.0-rc.0
+      - kubeflownotebookswg/codeserver-python:v1.9.0
     description: list of image options for VSCode
   rstudio-images:
     type: string
     default: |
-      - kubeflownotebookswg/rstudio-tidyverse:v1.9.0-rc.0
+      - kubeflownotebookswg/rstudio-tidyverse:v1.9.0
     description: list of image options for RStudio
   gpu-number-default:
     type: int

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: charmedkubeflow/jupyter-web-app:1.9.0-0fc426a
+    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.9.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes: https://github.com/canonical/notebook-operators/issues/389

I have compared tags v1.9.0 and v1.9.0-rc.1 for this files https://github.com/kubeflow/manifests/tree/v1.9.0?tab=readme-ov-file#notebooks-10

Only the images changed 