### PR TITLE
build: add rust toolchain and other build packages

### DIFF
--- a/charms/jupyter-controller/charmcraft.yaml
+++ b/charms/jupyter-controller/charmcraft.yaml
@@ -9,3 +9,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]

--- a/charms/jupyter-ui/charmcraft.yaml
+++ b/charms/jupyter-ui/charmcraft.yaml
@@ -9,3 +9,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
Adding the rust toolchain and other dependencies to avoid issues at build time.

Part of canonical/bundle-kubeflow#989