### PR TITLE
fix: markupsafe bug by updating chisme in all charms

### DIFF
--- a/charms/jupyter-controller/requirements-fmt.txt
+++ b/charms/jupyter-controller/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.4.2
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.1
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.2
     # via black
 tomli==2.0.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/jupyter-controller/requirements-integration.txt
+++ b/charms/jupyter-controller/requirements-integration.txt
@@ -12,11 +12,11 @@ attrs==23.2.0
     # via jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+bcrypt==4.2.0
     # via paramiko
-cachetools==5.3.3
+cachetools==5.4.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
@@ -26,11 +26,11 @@ cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements-integration.in
 charset-normalizer==3.3.2
     # via requests
-cryptography==42.0.8
+cryptography==43.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -38,13 +38,13 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
 executing==2.0.1
     # via stack-data
-google-auth==2.30.0
+google-auth==2.32.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
@@ -54,7 +54,7 @@ httpx==0.27.0
     # via
     #   -r requirements-integration.in
     #   lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
 idna==3.7
     # via
@@ -77,14 +77,14 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.5.2.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.2
+lightkube==0.15.3
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
@@ -102,7 +102,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.15.0
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
@@ -126,11 +126,11 @@ pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.1
+protobuf==5.27.2
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.0
     # via
@@ -156,7 +156,7 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.2.2
+pytest==8.3.1
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
@@ -209,7 +209,7 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tenacity==8.3.0
+tenacity==8.5.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
@@ -230,7 +230,7 @@ typing-extensions==4.12.2
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   kubernetes
     #   requests

--- a/charms/jupyter-controller/requirements-lint.txt
+++ b/charms/jupyter-controller/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.4.2
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==5.0.4
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.1
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.2.2
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.9.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==2.5.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==5.0.4.post1
     # via -r requirements-lint.in
 tomli==2.0.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/jupyter-controller/requirements-unit.txt
+++ b/charms/jupyter-controller/requirements-unit.txt
@@ -4,57 +4,86 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.4.0
+    # via httpx
+attrs==23.2.0
     # via jsonschema
-certifi==2023.7.22
+bcrypt==4.2.0
+    # via paramiko
+cachetools==5.4.0
+    # via google-auth
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.16.0
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-cosl==0.0.12
+cosl==0.0.15
     # via -r requirements.in
-coverage==7.3.0
+coverage==7.6.0
     # via -r requirements-unit.in
+cryptography==43.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
+google-auth==2.32.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.5
     # via httpx
-httpx==0.24.1
+httpx==0.27.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.7
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.0
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.5.2.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.3
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.30.0.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.15.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -63,49 +92,115 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
-    # via pytest
+packaging==24.1
+    # via
+    #   juju
+    #   pytest
+paramiko==3.4.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.5.0
     # via pytest
-pyrsistent==0.19.3
+protobuf==5.27.2
+    # via macaroonbakery
+pyasn1==0.6.0
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.0
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.8.2
+    # via cosl
+pydantic-core==2.20.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.0
+pytest==8.3.1
     # via
     #   -r requirements-unit.in
     #   pytest-mock
-pytest-mock==3.11.1
+pytest-mock==3.14.0
     # via -r requirements-unit.in
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.1
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.5.0
     # via charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
-typing-extensions==4.11.0
-    # via cosl
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.2
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==12.0
+    # via juju
+zipp==3.19.2
     # via importlib-resources

--- a/charms/jupyter-controller/requirements.txt
+++ b/charms/jupyter-controller/requirements.txt
@@ -4,51 +4,80 @@
 #
 #    pip-compile requirements.in
 #
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.4.0
+    # via httpx
+attrs==23.2.0
     # via jsonschema
-certifi==2023.7.22
+bcrypt==4.2.0
+    # via paramiko
+cachetools==5.4.0
+    # via google-auth
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.16.0
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-cosl==0.0.12
+cosl==0.0.15
     # via -r requirements.in
+cryptography==43.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.32.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.5
     # via httpx
-httpx==0.24.1
+httpx==0.27.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.7
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.0
     # via jsonschema
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.5.2.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.3
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.30.0.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.15.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -56,36 +85,102 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.1
+    # via juju
+paramiko==3.4.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyrsistent==0.19.3
+protobuf==5.27.2
+    # via macaroonbakery
+pyasn1==0.6.0
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.0
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.8.2
+    # via cosl
+pydantic-core==2.20.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.1
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.5.0
     # via charmed-kubeflow-chisme
-typing-extensions==4.11.0
-    # via cosl
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+toposort==1.10
+    # via juju
+typing-extensions==4.12.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.2
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==12.0
+    # via juju
+zipp==3.19.2
     # via importlib-resources

--- a/charms/jupyter-ui/requirements-fmt.txt
+++ b/charms/jupyter-ui/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.4.2
     # via -r requirements-fmt.in
-click==8.1.6
+click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.1
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.2.2
     # via black
 tomli==2.0.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/jupyter-ui/requirements-integration.txt
+++ b/charms/jupyter-ui/requirements-integration.txt
@@ -20,11 +20,11 @@ attrs==23.2.0
     #   jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.1.3
+bcrypt==4.2.0
     # via paramiko
-cachetools==5.3.3
+cachetools==5.4.0
     # via google-auth
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
@@ -34,11 +34,11 @@ cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.1
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements-integration.in
 charset-normalizer==3.3.2
     # via requests
-cryptography==42.0.8
+cryptography==43.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -48,7 +48,7 @@ deepdiff==6.2.1
     # via charmed-kubeflow-chisme
 dpath==2.2.0
     # via -r requirements-integration.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
@@ -58,7 +58,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.30.0
+google-auth==2.32.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
@@ -66,7 +66,7 @@ httpcore==1.0.5
     # via httpx
 httpx==0.27.0
     # via lightkube
-hvac==2.2.0
+hvac==2.3.0
     # via juju
 idna==3.7
     # via
@@ -90,14 +90,14 @@ jinja2==3.1.4
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.5.0.0
+juju==3.5.2.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.2
+lightkube==0.15.3
     # via charmed-kubeflow-chisme
 lightkube-models==1.30.0.8
     # via lightkube
@@ -117,7 +117,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.0
+ops==2.15.0
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
@@ -141,11 +141,11 @@ pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.47
     # via ipython
-protobuf==5.27.1
+protobuf==5.27.2
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.0
     # via
@@ -171,7 +171,7 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.2.2
+pytest==8.3.1
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
@@ -223,7 +223,7 @@ sniffio==1.3.1
     #   httpx
 stack-data==0.6.3
     # via ipython
-tenacity==8.3.0
+tenacity==8.5.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
@@ -244,7 +244,7 @@ typing-extensions==4.12.2
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   kubernetes
     #   requests

--- a/charms/jupyter-ui/requirements-lint.txt
+++ b/charms/jupyter-ui/requirements-lint.txt
@@ -4,46 +4,46 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.4.2
     # via -r requirements-lint.in
-click==8.1.6
+click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==5.0.4
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   flake8-docstrings
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
 flake8-docstrings==1.7.0
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.1
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.2.2
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.9.1
     # via flake8
 pydocstyle==6.3.0
     # via flake8-docstrings
-pyflakes==3.0.1
+pyflakes==2.5.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==5.0.4.post1
     # via -r requirements-lint.in
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -51,7 +51,7 @@ tomli==2.0.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/jupyter-ui/requirements-unit.txt
+++ b/charms/jupyter-ui/requirements-unit.txt
@@ -4,57 +4,86 @@
 #
 #    pip-compile requirements-unit.in
 #
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.4.0
+    # via httpx
+attrs==23.2.0
     # via jsonschema
-certifi==2023.7.22
+bcrypt==4.2.0
+    # via paramiko
+cachetools==5.4.0
+    # via google-auth
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.16.0
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-cosl==0.0.12
+cosl==0.0.15
     # via -r requirements.in
-coverage==7.3.0
+coverage==7.6.0
     # via -r requirements-unit.in
+cryptography==43.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
+google-auth==2.32.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.5
     # via httpx
-httpx==0.24.1
+httpx==0.27.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.7
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.0
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.5.2.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.3
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.30.0.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.15.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -63,27 +92,72 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
-    # via pytest
+packaging==24.1
+    # via
+    #   juju
+    #   pytest
+paramiko==3.4.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.5.0
     # via pytest
-pyrsistent==0.19.3
+protobuf==5.27.2
+    # via macaroonbakery
+pyasn1==0.6.0
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.0
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.8.2
+    # via cosl
+pydantic-core==2.20.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.0
+pytest==8.3.1
     # via -r requirements-unit.in
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.1
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
@@ -91,20 +165,41 @@ serialized-data-interface==0.3.6
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.5.0
     # via charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
+toposort==1.10
+    # via juju
 typing-extensions==4.12.2
-    # via cosl
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.2
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==12.0
+    # via juju
+zipp==3.19.2
     # via importlib-resources

--- a/charms/jupyter-ui/requirements.txt
+++ b/charms/jupyter-ui/requirements.txt
@@ -4,51 +4,80 @@
 #
 #    pip-compile requirements.in
 #
-anyio==3.7.1
-    # via httpcore
-attrs==23.1.0
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.4.0
+    # via httpx
+attrs==23.2.0
     # via jsonschema
-certifi==2023.7.22
+bcrypt==4.2.0
+    # via paramiko
+cachetools==5.4.0
+    # via google-auth
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   requests
-charmed-kubeflow-chisme==0.2.0
+cffi==1.16.0
+    # via
+    #   cryptography
+    #   pynacl
+charmed-kubeflow-chisme==0.4.2
     # via -r requirements.in
-charset-normalizer==3.2.0
+charset-normalizer==3.3.2
     # via requests
-cosl==0.0.12
+cosl==0.0.15
     # via -r requirements.in
+cryptography==43.0.0
+    # via paramiko
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.2.2
     # via anyio
+google-auth==2.32.0
+    # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.5
     # via httpx
-httpx==0.24.1
+httpx==0.27.0
     # via lightkube
-idna==3.4
+hvac==2.3.0
+    # via juju
+idna==3.7
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.0.1
+importlib-resources==6.4.0
     # via jsonschema
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.14.0
+juju==3.5.2.0
+    # via charmed-kubeflow-chisme
+kubernetes==30.1.0
+    # via juju
+lightkube==0.15.3
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.30.0.8
     # via lightkube
-markupsafe==2.1.3
+macaroonbakery==1.3.4
+    # via juju
+markupsafe==2.1.5
     # via jinja2
-ops==2.14.0
+mypy-extensions==1.0.0
+    # via typing-inspect
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+ops==2.15.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -56,39 +85,105 @@ ops==2.14.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
+packaging==24.1
+    # via juju
+paramiko==3.4.0
+    # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pyrsistent==0.19.3
+protobuf==5.27.2
+    # via macaroonbakery
+pyasn1==0.6.0
+    # via
+    #   juju
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.0
+    # via google-auth
+pycparser==2.22
+    # via cffi
+pydantic==2.8.2
+    # via cosl
+pydantic-core==2.20.1
+    # via pydantic
+pymacaroons==0.13.0
+    # via macaroonbakery
+pynacl==1.5.0
+    # via
+    #   macaroonbakery
+    #   paramiko
+    #   pymacaroons
+pyrfc3339==1.1
+    # via
+    #   juju
+    #   macaroonbakery
+pyrsistent==0.20.0
     # via jsonschema
+python-dateutil==2.9.0.post0
+    # via kubernetes
+pytz==2024.1
+    # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   cosl
+    #   juju
+    #   kubernetes
     #   lightkube
     #   ops
     #   serialized-data-interface
-requests==2.31.0
-    # via serialized-data-interface
-ruamel-yaml==0.17.32
+requests==2.32.3
+    # via
+    #   hvac
+    #   kubernetes
+    #   macaroonbakery
+    #   requests-oauthlib
+    #   serialized-data-interface
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
+ruamel-yaml==0.18.6
     # via charmed-kubeflow-chisme
-ruamel-yaml-clib==0.2.7
+ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.3.6
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-sniffio==1.3.0
+six==1.16.0
+    # via
+    #   kubernetes
+    #   macaroonbakery
+    #   pymacaroons
+    #   python-dateutil
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpcore
     #   httpx
-tenacity==8.2.2
+tenacity==8.5.0
     # via charmed-kubeflow-chisme
+toposort==1.10
+    # via juju
 typing-extensions==4.12.2
-    # via cosl
-urllib3==2.0.4
-    # via requests
-websocket-client==1.6.1
-    # via ops
-zipp==3.16.2
+    # via
+    #   annotated-types
+    #   anyio
+    #   cosl
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspect
+typing-inspect==0.9.0
+    # via juju
+urllib3==2.2.2
+    # via
+    #   kubernetes
+    #   requests
+websocket-client==1.8.0
+    # via
+    #   kubernetes
+    #   ops
+websockets==12.0
+    # via juju
+zipp==3.19.2
     # via importlib-resources


### PR DESCRIPTION
This should fix the `markupsafe` problem https://github.com/canonical/bundle-kubeflow/issues/883

I have updated chisme in all requirements
```
for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile \$(basename "{}") -P charmed-kubeflow-chisme --upgrade" \;; done
```