### PR TITLE
feat: Add terraform modules for jupyter-{controller,ui}

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,6 +64,17 @@ jobs:
     - run: sudo apt install tox
     - run: tox -e ${{ matrix.charm }}-lint
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    strategy:
+      matrix:
+        charm: [controller, ui]
+    with:
+      charm-path: ./charms/jupyter-${{ matrix.charm }}
+      model: kubeflow
+      channel: latest/edge
+
   bundle-integration:
     name: Bundle Integration
     runs-on: ubuntu-20.04

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -72,8 +72,6 @@ jobs:
         charm: [controller, ui]
     with:
       charm-path: ./charms/jupyter-${{ matrix.charm }}
-      model: kubeflow
-      channel: latest/edge
 
   bundle-integration:
     name: Bundle Integration

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 .coverage
 .idea
 geckodriver.log
+venv/
+.terraform*
+*.tfstate*

--- a/charms/jupyter-controller/terraform/README.md
+++ b/charms/jupyter-controller/terraform/README.md
@@ -19,7 +19,7 @@ The module offers the following configurable inputs:
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(number) | Map of charm resources revisions | False |
+| `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
 
 ### Outputs

--- a/charms/jupyter-controller/terraform/README.md
+++ b/charms/jupyter-controller/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for jupyter-controller
+
+This is a Terraform module facilitating the deployment of the jupyter-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(number) | Map of charm resources revisions | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "jupyter-controller" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "jupyter-controller" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/jupyter-controller/terraform/README.md
+++ b/charms/jupyter-controller/terraform/README.md
@@ -2,9 +2,6 @@
 
 This is a Terraform module facilitating the deployment of the jupyter-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-## Compatibility
-This terraform module is compatible with charms of version >= 1.9 due to changes in the charm's relations.
-
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 

--- a/charms/jupyter-controller/terraform/README.md
+++ b/charms/jupyter-controller/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the jupyter-controller charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+This terraform module is compatible with charms of version >= 1.9 due to changes in the charm's relations.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/charms/jupyter-controller/terraform/main.tf
+++ b/charms/jupyter-controller/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "jupyter_controller" {
+  charm {
+    name     = "jupyter-controller"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/jupyter-controller/terraform/outputs.tf
+++ b/charms/jupyter-controller/terraform/outputs.tf
@@ -1,0 +1,16 @@
+output "app_name" {
+  value = juju_application.jupyter_controller.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint  = "metrics-endpoint",
+    grafana_dashboard = "grafana-dashboard",
+  }
+}
+
+output "requires" {
+  value = {
+    logging = "logging"
+  }
+}

--- a/charms/jupyter-controller/terraform/variables.tf
+++ b/charms/jupyter-controller/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "model_name" {
 }
 
 variable "resources" {
-  description = "Map of resources revisions"
+  description = "Map of resources"
   type        = map(string)
   default     = null
 }

--- a/charms/jupyter-controller/terraform/variables.tf
+++ b/charms/jupyter-controller/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "jupyter-controller"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources revisions"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/jupyter-controller/terraform/versions.tf
+++ b/charms/jupyter-controller/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/jupyter-controller/tox.ini
+++ b/charms/jupyter-controller/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/jupyter-ui/terraform/README.md
+++ b/charms/jupyter-ui/terraform/README.md
@@ -19,7 +19,7 @@ The module offers the following configurable inputs:
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(number) | Map of charm resources revisions | False |
+| `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |
 
 ### Outputs

--- a/charms/jupyter-ui/terraform/README.md
+++ b/charms/jupyter-ui/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for jupyter-ui
+
+This is a Terraform module facilitating the deployment of the jupyter-ui charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(number) | Map of charm resources revisions | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "jupyter-ui" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "jupyter-ui" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/jupyter-ui/terraform/README.md
+++ b/charms/jupyter-ui/terraform/README.md
@@ -2,9 +2,6 @@
 
 This is a Terraform module facilitating the deployment of the jupyter-ui charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
-## Compatibility
-This terraform module is compatible with charms of version >= 1.9 due to changes in the charm's relations.
-
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
 

--- a/charms/jupyter-ui/terraform/README.md
+++ b/charms/jupyter-ui/terraform/README.md
@@ -3,7 +3,7 @@
 This is a Terraform module facilitating the deployment of the jupyter-ui charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 ## Compatibility
-This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+This terraform module is compatible with charms of version >= 1.9 due to changes in the charm's relations.
 
 ## Requirements
 This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.

--- a/charms/jupyter-ui/terraform/main.tf
+++ b/charms/jupyter-ui/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "jupyter_ui" {
+  charm {
+    name     = "jupyter-ui"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/jupyter-ui/terraform/outputs.tf
+++ b/charms/jupyter-ui/terraform/outputs.tf
@@ -8,8 +8,8 @@ output "provides" {
 
 output "requires" {
   value = {
-    ingress = "ingress",
+    ingress         = "ingress",
     dashboard_links = "dashboard-links",
-    logging = "logging",
+    logging         = "logging",
   }
 }

--- a/charms/jupyter-ui/terraform/outputs.tf
+++ b/charms/jupyter-ui/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "app_name" {
+  value = juju_application.jupyter_ui.name
+}
+
+output "provides" {
+  value = {}
+}
+
+output "requires" {
+  value = {
+    ingress = "ingress",
+    dashboard_links = "dashboard-links",
+    logging = "logging",
+  }
+}

--- a/charms/jupyter-ui/terraform/variables.tf
+++ b/charms/jupyter-ui/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "model_name" {
 }
 
 variable "resources" {
-  description = "Map of resources revisions"
+  description = "Map of resources"
   type        = map(string)
   default     = null
 }

--- a/charms/jupyter-ui/terraform/variables.tf
+++ b/charms/jupyter-ui/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "jupyter-ui"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources revisions"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/jupyter-ui/terraform/versions.tf
+++ b/charms/jupyter-ui/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/jupyter-ui/tox.ini
+++ b/charms/jupyter-ui/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Create a `terraform/` directory for each of the charms that hosts their individual Terraform modules. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit) and it is based on what was done in canonical/argo-operators#198.

To test the modules:
- Clone the repository and switch this PR's branch.
- For each charm:
  - `cd` into its directory 
  - First run `tox -e tflint` to ensure that linting is correct
  - Run `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.

Ref #405
Ref #404