### PR TITLE
chore: update controller and web-app to 1.10.0-rc.0

### DIFF
--- a/charms/jupyter-controller/metadata.yaml
+++ b/charms/jupyter-controller/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/notebook-controller:1.9.0-249e99c
+    upstream-source: docker.io/kubeflownotebookswg/notebook-controller:v1.10.0-rc.0
 provides:
   metrics-endpoint:
     interface: prometheus_scrape

--- a/charms/jupyter-ui/config.yaml
+++ b/charms/jupyter-ui/config.yaml
@@ -25,21 +25,22 @@ options:
   jupyter-images:
     type: string
     default: |
-      - kubeflownotebookswg/jupyter-scipy:v1.9.0
-      - kubeflownotebookswg/jupyter-pytorch-full:v1.9.0
-      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.9.0
-      - kubeflownotebookswg/jupyter-tensorflow-full:v1.9.0
-      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.9.0
+      - kubeflownotebookswg/jupyter-scipy:v1.10.0-rc.0
+      - kubeflownotebookswg/jupyter-pytorch-full:v1.10.0-rc.0
+      - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.10.0-rc.0
+      - kubeflownotebookswg/jupyter-pytorch-gaudi-full:v1.10.0-rc.0
+      - kubeflownotebookswg/jupyter-tensorflow-full:v1.10.0-rc.0
+      - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.10.0-rc.0
     description: list of image options for Jupyter Notebook
   vscode-images:
     type: string
     default: |
-      - kubeflownotebookswg/codeserver-python:v1.9.0
+      - kubeflownotebookswg/codeserver-python:v1.10.0-rc.0
     description: list of image options for VSCode
   rstudio-images:
     type: string
     default: |
-      - kubeflownotebookswg/rstudio-tidyverse:v1.9.0
+      - kubeflownotebookswg/rstudio-tidyverse:v1.10.0-rc.0
     description: list of image options for RStudio
   gpu-number-default:
     type: int

--- a/charms/jupyter-ui/metadata.yaml
+++ b/charms/jupyter-ui/metadata.yaml
@@ -12,7 +12,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/charmedkubeflow/jupyter-web-app:1.9.0-2920db1
+    upstream-source: docker.io/kubeflownotebookswg/jupyter-web-app:v1.10.0-rc.0
 requires:
   ingress:
     interface: ingress

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -169,6 +169,7 @@ class JupyterUI(CharmBase):
             "UI": config["ui"],
             "USERID_HEADER": "kubeflow-userid",
             "USERID_PREFIX": "",
+            "METRICS": 1,
         }
 
         return ret_env_vars


### PR DESCRIPTION
This commit updates the charms in this repository to the 1.10.0-rc.0 version, which includes:
* Using upstream's latest 1.10.0-rc.0 image for both charms
* Updating the list of images for Jupyter, Rstudio and VSCode from the dropdown menu
* Adding a METRICS environment variable to the web-app charm to match upstream

See https://github.com/kubeflow/manifests/pull/2995/ for reference on the changes.