### PR TITLE
chore: migrate GH runners to ubuntu 24.04

### DIFF
--- a/.github/workflows/build_and_scan_images.yaml
+++ b/.github/workflows/build_and_scan_images.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,7 +169,7 @@ jobs:
           # Pass the path where the charm artefact is downloaded to the tox command
           # FIXME: Right now the complete path is half hardcoded to <charm name>_ubuntu@20.04-amd64.charm
           # We need to find a better way to dynamically get this value
-          sg snap_microk8s -c "tox -e ${{ matrix.charm }}-integration -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm"
+          tox -e ${{ matrix.charm }}-integration -- --model kubeflow --charm-path=${{ github.workspace }}/charms/${{ matrix.charm }}/${{ matrix.charm }}_ubuntu@20.04-amd64.charm
 
   test-bundle:
     name: Test the bundle
@@ -208,7 +208,7 @@ jobs:
           tar xf geckodriver-v0.28.0-linux64.tar.gz
           sudo mv geckodriver /usr/local/bin
           juju add-model kubeflow
-          sg snap_microk8s -c "tox -e integration -- --model kubeflow --charms-path=${{ github.workspace }}/charms/"
+          tox -e integration -- --model kubeflow --charms-path=${{ github.workspace }}/charms/
       
       - run: kubectl get all -A
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -158,11 +163,6 @@ jobs:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v5.3.0
-        with:
-          python-version: 3.8
-
       - name: Integration tests
         run: |
           juju add-model kubeflow
@@ -178,6 +178,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,11 +62,11 @@ jobs:
           - jupyter-controller
           - jupyter-ui
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v5.3.0
         with:
           python-version: 3.8
-      - uses: actions/checkout@v3
       - run: python3 -m pip install tox
       - run: tox -e ${{ matrix.charm }}-lint
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -62,13 +62,17 @@ jobs:
           - jupyter-controller
           - jupyter-ui
     steps:
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
       - uses: actions/checkout@v3
       - run: python3 -m pip install tox
       - run: tox -e ${{ matrix.charm }}-lint
 
   unit:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +81,10 @@ jobs:
           - jupyter-ui
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
       - run: python3 -m pip install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
@@ -124,7 +132,7 @@ jobs:
     name: Integration tests (microk8s)
     needs:
       - build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +158,11 @@ jobs:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*
           merge-multiple: true
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: 3.8
+
       - name: Integration tests
         run: |
           juju add-model kubeflow
@@ -161,7 +174,7 @@ jobs:
   test-bundle:
     name: Test the bundle
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:


### PR DESCRIPTION
Closes #442 

* Updates the runners from 20.04 to 24.04
* Sets up Python3.8 before installing requirements since they are compiled with 3.8
* Removes `sg snap_microk8s` from the integration tests commands which turns out is not needed