### PR TITLE
fix: Update description of cull-idle-time from config.yaml

### DIFF
--- a/charms/jupyter-controller/config.yaml
+++ b/charms/jupyter-controller/config.yaml
@@ -6,7 +6,7 @@ options:
   cull-idle-time:
     type: int
     default: 1440
-    description: The amount of time (in seconds) that a Jupyter notebook server can remain idle before it is automatically shut down.
+    description: The amount of time (in minutes) that a Jupyter notebook server can remain idle before it is automatically shut down.
   enable-culling:
     type: boolean
     default: true


### PR DESCRIPTION
Update the description of cull-idle-time from ```seconds``` to ```minutes```
- 1440min = 60min * 24h

Reference
- [Kubeflow notebook-controller](https://github.com/kubeflow/kubeflow/blob/4a26c7b5e9575410613faf7df6735aa1883a2d24/components/notebook-controller/controllers/culling_controller.go#L28)