### PR TITLE
fix: install binary package for setuptools_scm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
     with:
       path-to-charm-directory: ${{ matrix.charm }}
+      cache: false  # TODO: Remove once charms are added to charmcraftcache
 
   release:
     strategy:

--- a/charms/jupyter-controller/charmcraft.yaml
+++ b/charms/jupyter-controller/charmcraft.yaml
@@ -34,6 +34,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
@@ -47,7 +49,7 @@ parts:
       else
         apt-get install rustup -y
       fi
-      
+
       # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
       # archive—which means the rustup version could be updated at any time. Print rustup version
       # to build log to make changes to the snap's rustup version easier to track
@@ -57,7 +59,7 @@ parts:
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
       rustup default 1.83.0  # renovate: charmcraft-rust-latest
-      
+
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"

--- a/charms/jupyter-controller/constraints.txt
+++ b/charms/jupyter-controller/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/jupyter-ui/charmcraft.yaml
+++ b/charms/jupyter-ui/charmcraft.yaml
@@ -34,6 +34,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
@@ -47,7 +49,7 @@ parts:
       else
         apt-get install rustup -y
       fi
-      
+
       # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
       # archive—which means the rustup version could be updated at any time. Print rustup version
       # to build log to make changes to the snap's rustup version easier to track
@@ -57,7 +59,7 @@ parts:
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
       rustup default 1.83.0  # renovate: charmcraft-rust-latest
-      
+
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"

--- a/charms/jupyter-ui/constraints.txt
+++ b/charms/jupyter-ui/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
Closes https://github.com/canonical/notebook-operators/issues/456

We need to then cherry-pick this and https://github.com/canonical/notebook-operators/pull/455 to `track/1.10`