### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/charms/jupyter-controller/requirements-integration.txt
+++ b/charms/jupyter-controller/requirements-integration.txt
@@ -28,7 +28,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -55,6 +55,7 @@ httpcore==1.0.7
 httpx==0.27.2
     # via
     #   -r requirements-integration.in
+    #   charmed-kubeflow-chisme
     #   lightkube
 hvac==2.3.0
     # via juju

--- a/charms/jupyter-controller/tests/integration/charms_dependencies.py
+++ b/charms/jupyter-controller/tests/integration/charms_dependencies.py
@@ -1,0 +1,14 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+JUPYTER_UI = CharmSpec(charm="jupyter-ui", channel="latest/edge", trust=True)
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", trust=True, config={"kind": "ingress"}
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    trust=True,
+    config={"default-gateway": "kubeflow-gateway"},
+)

--- a/charms/jupyter-controller/tests/integration/test_charm.py
+++ b/charms/jupyter-controller/tests/integration/test_charm.py
@@ -17,6 +17,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from charms_dependencies import ISTIO_GATEWAY, ISTIO_PILOT, JUPYTER_UI
 from httpx import HTTPStatusError
 from lightkube import ApiError, Client
 from lightkube.generic_resource import create_namespaced_resource
@@ -28,18 +29,7 @@ log = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-JUPYTER_UI = "jupyter-ui"
-JUPYTER_UI_CHANNEL = "latest/edge"
-JUPYTER_UI_TRUST = True
-
-ISTIO_OPERATORS_CHANNEL = "latest/edge"
-ISTIO_PILOT = "istio-pilot"
-ISTIO_PILOT_TRUST = True
-ISTIO_PILOT_CONFIG = {"default-gateway": "kubeflow-gateway"}
-ISTIO_GATEWAY = "istio-gateway"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
-ISTIO_GATEWAY_TRUST = True
-ISTIO_GATEWAY_CONFIG = {"kind": "ingress"}
 
 
 @pytest.mark.abort_on_fail
@@ -47,20 +37,20 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
     """Test build and deploy."""
     # Deploy istio-operators first
     await ops_test.model.deploy(
-        entity_url=ISTIO_PILOT,
-        channel=ISTIO_OPERATORS_CHANNEL,
-        config=ISTIO_PILOT_CONFIG,
-        trust=ISTIO_PILOT_TRUST,
+        entity_url=ISTIO_PILOT.charm,
+        channel=ISTIO_PILOT.channel,
+        config=ISTIO_PILOT.config,
+        trust=ISTIO_PILOT.trust,
     )
     await ops_test.model.deploy(
-        entity_url=ISTIO_GATEWAY,
+        entity_url=ISTIO_GATEWAY.charm,
         application_name=ISTIO_GATEWAY_APP_NAME,
-        channel=ISTIO_OPERATORS_CHANNEL,
-        config=ISTIO_GATEWAY_CONFIG,
-        trust=ISTIO_GATEWAY_TRUST,
+        channel=ISTIO_GATEWAY.channel,
+        config=ISTIO_GATEWAY.config,
+        trust=ISTIO_GATEWAY.trust,
     )
 
-    await ops_test.model.integrate(ISTIO_PILOT, ISTIO_GATEWAY_APP_NAME)
+    await ops_test.model.integrate(ISTIO_PILOT.charm, ISTIO_GATEWAY_APP_NAME)
 
     await ops_test.model.wait_for_idle(
         status="active",
@@ -69,9 +59,11 @@ async def test_build_and_deploy(ops_test: OpsTest, request):
         timeout=300,
     )
     # Deploy jupyter-ui and relate to istio
-    await ops_test.model.deploy(JUPYTER_UI, channel=JUPYTER_UI_CHANNEL, trust=JUPYTER_UI_TRUST)
-    await ops_test.model.integrate(JUPYTER_UI, ISTIO_PILOT)
-    await ops_test.model.wait_for_idle(apps=[JUPYTER_UI], status="active", timeout=60 * 15)
+    await ops_test.model.deploy(
+        JUPYTER_UI.charm, channel=JUPYTER_UI.channel, trust=JUPYTER_UI.trust
+    )
+    await ops_test.model.integrate(JUPYTER_UI.charm, ISTIO_PILOT.charm)
+    await ops_test.model.wait_for_idle(apps=[JUPYTER_UI.charm], status="active", timeout=60 * 15)
 
     # Keep the option to run the integration tests locally
     # by building the charm and then deploying


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
