### PR TITLE
feat(terraform): add variable for setting the charm base

### DIFF
--- a/charms/jupyter-controller/terraform/README.md
+++ b/charms/jupyter-controller/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/jupyter-controller/terraform/main.tf
+++ b/charms/jupyter-controller/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "jupyter_controller" {
   charm {
     name     = "jupyter-controller"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/jupyter-controller/terraform/variables.tf
+++ b/charms/jupyter-controller/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "jupyter-controller"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@20.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/jupyter-ui/terraform/README.md
+++ b/charms/jupyter-ui/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/jupyter-ui/terraform/main.tf
+++ b/charms/jupyter-ui/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "jupyter_ui" {
   charm {
     name     = "jupyter-ui"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/jupyter-ui/terraform/variables.tf
+++ b/charms/jupyter-ui/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "jupyter-ui"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@20.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Adds a variable to allow setting the base for `jupyter-controller` and `jupyter-ui` modules.
This variable is necessary since we've done the base migration to 24.04 in #471.

Following this PR, we should send a PR to https://github.com/canonical/charmed-kubeflow-solutions to:
1. set the base for the `jupyter-*` modules to `24.04`
2. set the channel for the `jupyter-*` modules to `1.10/edge`

The reason for this is to integrate the notebook image with the feast lib in the terraform solution, i.e. the change done in #470. This change is not yet in stable.