### PR TITLE
fix(chore): upgrade charmed-kubeflow-chisme after upstream bugfix

### DIFF
--- a/charms/jupyter-controller/requirements-integration.in
+++ b/charms/jupyter-controller/requirements-integration.in
@@ -7,5 +7,6 @@ pytest-operator
 pyyaml
 requests
 tenacity
-# This is required due to the abstraction of cos integration
-charmed-kubeflow-chisme>=0.4.0
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11

--- a/charms/jupyter-controller/requirements-integration.txt
+++ b/charms/jupyter-controller/requirements-integration.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.9
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests

--- a/charms/jupyter-controller/requirements.in
+++ b/charms/jupyter-controller/requirements.in
@@ -1,4 +1,6 @@
-charmed-kubeflow-chisme
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 lightkube
 ops
 # from prometheus_k8s.v0.prometheus_scrape.py

--- a/charms/jupyter-controller/requirements.txt
+++ b/charms/jupyter-controller/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -41,7 +41,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/jupyter-ui/requirements-integration.in
+++ b/charms/jupyter-ui/requirements-integration.in
@@ -6,5 +6,6 @@ pytest
 pytest-operator
 pyyaml
 tenacity
-# This is required due to the abstraction of cos integration
-charmed-kubeflow-chisme>=0.4.0
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11

--- a/charms/jupyter-ui/requirements-integration.txt
+++ b/charms/jupyter-ui/requirements-integration.txt
@@ -34,7 +34,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -61,7 +61,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/jupyter-ui/requirements.in
+++ b/charms/jupyter-ui/requirements.in
@@ -1,4 +1,6 @@
-charmed-kubeflow-chisme
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 lightkube
 ops
 pyyaml

--- a/charms/jupyter-ui/requirements.txt
+++ b/charms/jupyter-ui/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -41,7 +41,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10


### PR DESCRIPTION
Bumps the chisme version to `>=0.4.11` bring the fix for https://github.com/canonical/charmed-kubeflow-chisme/issues/155
This is currently blocking the CI, see [this run](https://github.com/canonical/notebook-operators/actions/runs/15779201518/job/44481306149) for example.