### PR TITLE
terraform: change default base of jupyter-ui to 24.04

### DIFF
--- a/charms/jupyter-ui/terraform/variables.tf
+++ b/charms/jupyter-ui/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "base" {
   description = "Application base"
   type        = string
-  default     = "ubuntu@20.04"
+  default     = "ubuntu@24.04"
 }
 
 variable "channel" {


### PR DESCRIPTION
Updates the default base of `jupyter-ui` terraform module to `24.04` now that the charm with `24.04` base is released to stable (done in [this action](https://github.com/canonical/notebook-operators/actions/runs/15881425393)).
This is needed for the Feast release, in order to have the feast notebook image in stable (merged in #470). 

Note that `jupyter-controller` charm was not promoted hence I did not update the base for it in the terraform module, the reason is it has no changes required for Feast.
The change for `jupyter-controller` should be done in a follow-up PR, along with https://github.com/canonical/bundle-kubeflow/issues/1292.