### PR TITLE
fix: bump chisme in requirements-unit.txt files

### DIFF
--- a/charms/jupyter-controller/requirements-unit.txt
+++ b/charms/jupyter-controller/requirements-unit.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -43,7 +43,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/charms/jupyter-ui/requirements-unit.txt
+++ b/charms/jupyter-ui/requirements-unit.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -43,7 +43,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10


### PR DESCRIPTION
Bumps the `charmed-kubeflow-chisme` version in `requirements-unit.txt` for `jupyter-controller` and `jupyter-ui`. This was missed during bumping chisme in #478.
Note that this change is not needed for `main` as it will be overwritten by migration to poetry in #482, it is needed for the track branch because we've decided not to backport the poetry migration.