### PR TITLE
chore: bump pytorch image for CVE fixes

### DIFF
--- a/charms/jupyter-ui/config.yaml
+++ b/charms/jupyter-ui/config.yaml
@@ -26,7 +26,7 @@ options:
     type: string
     default: |
       - charmedkubeflow/jupyter-scipy:1.10.0-0be57a5
-      - charmedkubeflow/jupyter-pytorch-full:v1.10.0-ef1fc67
+      - docker.io/charmedkubeflow/jupyter-pytorch-full:v1.10.0-4cbdf49
       - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.10.0-rc.1
       - kubeflownotebookswg/jupyter-pytorch-gaudi-full:v1.10.0-rc.1
       - charmedkubeflow/jupyter-tensorflow-full:1.10.0-448e378
@@ -109,7 +109,7 @@ options:
     # upstream.
     default: '["access-ml-pipeline"]'
     description: |
-      The PodDefaults that are selected by default in the New Notebook UI when creating a new Notebook. 
+      The PodDefaults that are selected by default in the New Notebook UI when creating a new Notebook.
       Inputs is a JSON/YAML list of the names of the PodDefaults.
       The New Notebook UI will always show all PodDefaults available to the user - this only defines
       which PodDefaults are selected by default.


### PR DESCRIPTION
Cherry-pick https://github.com/canonical/kubeflow-rocks/pull/249

Note, we can't just cherry-pick https://github.com/canonical/notebook-operators/pull/496 since in this branch we haven't yet split the `conifg.yaml` to separate YAML files for each server category https://github.com/canonical/bundle-kubeflow/issues/1328