### PR TITLE
chore: pin Juju provider for Terraform

### DIFF
--- a/charms/jupyter-controller/terraform/versions.tf
+++ b/charms/jupyter-controller/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/charms/jupyter-ui/terraform/versions.tf
+++ b/charms/jupyter-ui/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Temporary workaround for https://github.com/canonical/bundle-kubeflow/issues/1353

Note to reviewer: Release CI is failing, and will be resolved in #515. For now, we can merge this one to unblock terraform checks.