### PR TITLE
chore(backport): update data platform workflows version (#515)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,18 +16,18 @@ on:
         value: ${{ jobs.build.outputs.artifact-prefix }}
       charm-paths:
         description: paths for all charms in this repo
-        value: ${{ jobs.get-charm-paths-channel.outputs.charm-paths }}
-      channel:
-        description: Charmhub channel the charms are released to
-        value: ${{ jobs.get-charm-paths-channel.outputs.charm-channel }}
+        value: ${{ jobs.get-charm-paths-track.outputs.charm-paths }}
+      track:
+        description: Charmhub track determined from branch name
+        value: ${{ jobs.get-charm-paths-track.outputs.track }}
 
 jobs:
-  get-charm-paths-channel:
-    name: Get charm paths and charmhub channel
+  get-charm-paths-track:
+    name: Get charm paths and track
     runs-on: ubuntu-latest
     outputs:
       charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
-      charm-channel: ${{ steps.select-channel.outputs.name }}
+      track: ${{ steps.determine-track.outputs.track }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,17 +35,34 @@ jobs:
       - name: Get paths for all charms in this repo
         id: get-charm-paths
         uses: canonical/kubeflow-ci/actions/get-charm-paths@main
-      - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.6.2
-        id: select-channel
+      - name: Determine track
+        id: determine-track
+        shell: python
+        run: |
+          import os
+          
+          if "${{ github.event_name }}" == "pull_request":
+              ref = "${{ github.base_ref }}"
+          else:
+              ref = "${{ github.ref_name }}"
+          
+          if ref.startswith("track/"):
+              track = ref.removeprefix("track/")
+          else:
+              track = "latest"
+          
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"track={track}\n")
+          
+          print(f"Track: {track}")
 
   lib-check:
     name: Check libraries
     needs:
-      - get-charm-paths-channel
+      - get-charm-paths-track
     strategy:
       matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-channel.outputs.charm-paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
     with:
@@ -83,22 +100,22 @@ jobs:
   terraform-checks:
     name: Terraform
     needs:
-      - get-charm-paths-channel
+      - get-charm-paths-track
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
     strategy:
       matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-channel.outputs.charm-paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
     with:
       charm-path: ${{ matrix.charm }}
 
   build:
     strategy:
       matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-channel.outputs.charm-paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
     name: Build charm | ${{ matrix.charm }}
     needs:
-      - get-charm-paths-channel
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
+      - get-charm-paths-track
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v38.0.0
     with:
       path-to-charm-directory: ${{ matrix.charm }}
       cache: false  # TODO: Remove once charms are added to charmcraftcache
@@ -106,18 +123,17 @@ jobs:
   release:
     strategy:
       matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-channel.outputs.charm-paths) }}
+        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
     name: Release charm to Charmhub branch | ${{ matrix.charm }}
     if: ${{ github.event_name == 'pull_request' }}
     needs:
-      - get-charm-paths-channel
+      - get-charm-paths-track
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v38.0.0
     with:
-      channel: ${{ needs.get-charm-paths-channel.outputs.charm-channel }}
+      track: ${{ needs.get-charm-paths-track.outputs.track }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
-      create-git-tags: false
     secrets:
       charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,9 @@ jobs:
     name: Release charm | ${{ matrix.charm }}
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v38.0.0
     with:
-      channel: ${{ needs.ci-tests.outputs.channel }}
+      track: ${{ needs.ci-tests.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
     secrets:


### PR DESCRIPTION
Backports #515 to fix CI, part of resolving https://github.com/canonical/bundle-kubeflow/issues/1372

## Summary
* chore: update data platform workflows version to v38.0.0
* adjust to breaking change made in v32.0.0
* fix: remove deprecated input create-tags
* replace select channel with track
