### PR TITLE
chore: bump Rust version to 1.92.0

### DIFF
--- a/charms/jupyter-controller/charmcraft.yaml
+++ b/charms/jupyter-controller/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/jupyter-ui/charmcraft.yaml
+++ b/charms/jupyter-ui/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
## Description

Ref https://github.com/canonical/bundle-kubeflow/issues/1381

This PR updates the Rust version in charmcraft.yaml file(s) to 1.92.0.

## Changes

- Updated `rustup default` version to 1.92.0 in charmcraft.yaml file(s)

This ensures all charms use a consistent and up-to-date Rust version.
