### PR TITLE
fix: check storage mounts only when Pebble is ready

### DIFF
--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -621,6 +621,7 @@ class JupyterUI(CharmBase):
             self._check_leader()
             self._deploy_k8s_resources()
             if self._is_container_ready():
+                self._check_storage()
                 self._update_layer()
                 self._update_spawner_ui_config()
                 self._check_istio_relations()


### PR DESCRIPTION
Resolves https://github.com/canonical/notebook-operators/issues/526 by checking the storage only when the container (and thus Pebble) is ready.

**_Note that the workflows `Apply Terraform` and `Integration tests (microk8s) (jupyter-controller, integration)` will keep failing until this is merged, as they employ the charm of the UI on `latest/edge` instead of building it from this branch._**

Also note that [the commit to upgrade rust](https://github.com/canonical/notebook-operators/pull/527/commits/c3d84d15ba61475acb56febf99288ce9d59da55d) will be undone when rebasing onto `main` after https://github.com/canonical/notebook-operators/pull/525 is merged.