### PR TITLE
ci: add missing script to get charm paths

### DIFF
--- a/.github/workflows/get-charm-paths.sh.sh
+++ b/.github/workflows/get-charm-paths.sh.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+# Finds the charms in this repo, outputting them as JSON
+# Will return one of:
+# * the relative paths of the directories listed in `./charms`, if that directory exists
+# * "./", if the root directory has a "metadata.yaml" file
+# * otherwise, error
+#
+# Modified from: https://stackoverflow.com/questions/63517732/github-actions-build-matrix-for-lambda-functions/63736071#63736071
+CHARMS_DIR="./charms"
+if [ -d "$CHARMS_DIR" ];
+then
+	CHARM_PATHS=$(find $CHARMS_DIR -maxdepth 1 -type d -not -path '*/\.*' -not -path "$CHARMS_DIR")
+else
+	if [ -f "./metadata.yaml" ]
+	then
+		CHARM_PATHS="./"
+	else
+		echo "Cannot find valid charm directories - aborting"
+		exit 1
+	fi
+fi
+
+# Convert output to JSON string format
+# { charm_paths: [...] }
+CHARM_PATHS_LIST=$(echo "$CHARM_PATHS" | jq -c --slurp --raw-input 'split("\n")[:-1]')
+
+echo "Found CHARM_PATHS_LIST: $CHARM_PATHS_LIST"
+
+echo "::set-output name=CHARM_PATHS_LIST::$CHARM_PATHS_LIST"


### PR DESCRIPTION
This pull request integrates https://github.com/canonical/notebook-operators/pull/528 by providing the missing script it requires. See its old version from https://github.com/canonical/notebook-operators/commit/fd6a70b80d3c163f23916f6ca6497852f5c198a4.