### PR TITLE
ci: re-enable Charmcraft's cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v38.0.0
     with:
       path-to-charm-directory: ${{ matrix.charm }}
-      cache: false  # NOTE: temporary change for a problem with the workflow, TODO: restore this to "true"
+      cache: true
 
   release:
     strategy:


### PR DESCRIPTION
This pull request undoes the temporary change mentioned in https://github.com/canonical/notebook-operators/pull/528.