### PR TITLE
chore: use new `istio-gateway-service-account` config for Kubeflow Profiles

### DIFF
--- a/charms/jupyter-controller/tests/integration/charms_dependencies.py
+++ b/charms/jupyter-controller/tests/integration/charms_dependencies.py
@@ -18,6 +18,6 @@ KUBEFLOW_PROFILES = CharmSpec(
     trust=True,
     config={
         "service-mesh-mode": "istio-ambient",
-        "istio-gateway-principal": "cluster.local/ns/kubeflow/sa/istio-ingress-k8s-istio",
+        "istio-gateway-service-account": "istio-ingress-k8s-istio",
     },
 )


### PR DESCRIPTION
After merging https://github.com/canonical/kubeflow-profiles-operator/pull/297, the configuration option for Ambient needs to be updated.