### PR TITLE
chore: pin charm dependencies in tests (track/1.11)

### DIFF
--- a/charms/jupyter-controller/tests/integration/charms_dependencies.py
+++ b/charms/jupyter-controller/tests/integration/charms_dependencies.py
@@ -2,19 +2,19 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-JUPYTER_UI = CharmSpec(charm="jupyter-ui", channel="latest/edge", trust=True)
+JUPYTER_UI = CharmSpec(charm="jupyter-ui", channel="1.11/edge", trust=True)
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", trust=True, config={"kind": "ingress"}
+    charm="istio-gateway", channel="1.28/edge", trust=True, config={"kind": "ingress"}
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     trust=True,
     config={"default-gateway": "kubeflow-gateway"},
 )
 KUBEFLOW_PROFILES = CharmSpec(
     charm="kubeflow-profiles",
-    channel="latest/edge",
+    channel="2.0/edge",
     trust=True,
     config={
         "service-mesh-mode": "istio-ambient",


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### Same-repo (pinned to `track/1.11`)
- `jupyter-ui`: `latest/edge` → `1.11/edge`

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track) — entries marked _(override)_ are pinned via `config.FALLBACK_OVERRIDES`
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`
- `kubeflow-profiles`: `latest/edge` → `2.0/edge` _(override)_

Refs: canonical/bundle-kubeflow#1379
