### PR TITLE
chore: pin charm dependencies in tests (track/1.10)

### DIFF
--- a/charms/jupyter-controller/tests/integration/charms_dependencies.py
+++ b/charms/jupyter-controller/tests/integration/charms_dependencies.py
@@ -4,11 +4,11 @@ from charmed_kubeflow_chisme.testing import CharmSpec
 
 JUPYTER_UI = CharmSpec(charm="jupyter-ui", channel="1.10/stable", trust=True)
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="1.24/stable", trust=True, config={"kind": "ingress"}
+    charm="istio-gateway", channel="1.28/stable", trust=True, config={"kind": "ingress"}
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="1.24/stable",
+    channel="1.28/stable",
     trust=True,
     config={"default-gateway": "kubeflow-gateway"},
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11)
- `istio-gateway`: `1.24/stable` → `1.28/stable`
- `istio-pilot`: `1.24/stable` → `1.28/stable`

Refs: canonical/bundle-kubeflow#1379
