### PR TITLE
fix: handle multiple istio-ingress-route relations in jupyter-ui

### DIFF
--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -581,11 +581,20 @@ class JupyterUI(CharmBase):
         return interfaces
 
     def _check_istio_relations(self):
-        """Check that both ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self.model.get_relation(ISTIO_INGRESS_ROUTE_RELATION)
-        sidecar_relation = self.model.get_relation(INGRESS_RELATION)
+        """Validate the charm's ingress relations are mutually exclusive.
 
-        if ambient_relation and sidecar_relation:
+        The charm supports both ambient ingress (via the '{ISTIO_INGRESS_ROUTE_RELATION}'
+        endpoint) and sidecar ingress (via the '{INGRESS_RELATION}' endpoint), but the two
+        cannot be used at the same time. Each endpoint may hold any number of relations,
+        so this inspects the full list of relations on each endpoint.
+
+        Raises:
+            CheckFailed: with BlockedStatus if relations exist on both endpoints.
+        """
+        ambient_relations = self.model.relations[ISTIO_INGRESS_ROUTE_RELATION]
+        sidecar_relations = self.model.relations[INGRESS_RELATION]
+
+        if ambient_relations and sidecar_relations:
             self.logger.error(
                 f"Both '{ISTIO_INGRESS_ROUTE_RELATION}' and '{INGRESS_RELATION}' "
                 "relations are present, remove one to unblock."

--- a/charms/jupyter-ui/src/charm.py
+++ b/charms/jupyter-ui/src/charm.py
@@ -218,6 +218,8 @@ class JupyterUI(CharmBase):
             ],
         )
         # Only submit config if we are a leader
+        # submit_config publishes this same config to every istio-ingress-route
+        # relation, so all related ingress providers are (re)configured at once.
         if self.unit.is_leader():
             self.ingress.submit_config(config)
 

--- a/charms/jupyter-ui/tests/integration/test_charm_ambient.py
+++ b/charms/jupyter-ui/tests/integration/test_charm_ambient.py
@@ -41,8 +41,6 @@ HEADERS = {
 HTTP_PATH = "/jupyter/"
 EXPECTED_RESPONSE_TEXT = "Jupyter Management UI"
 # A second istio-ingress-k8s instance used to verify multiple-ingress support.
-# NOTE: Juju rejects application names whose final segment is all digits (e.g.
-# "istio-ingress-k8s-2"), so the suffix must contain a letter.
 SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
 INGRESS_CHANNEL = "2/stable"
 # Name of the HTTPRoute submitted by jupyter-ui (see charm._configure_ambient_ingress).

--- a/charms/jupyter-ui/tests/integration/test_charm_ambient.py
+++ b/charms/jupyter-ui/tests/integration/test_charm_ambient.py
@@ -9,17 +9,21 @@ import logging
 from pathlib import Path
 
 import dpath
+import lightkube
 import pytest
 import tenacity
 import yaml
 from charmed_kubeflow_chisme.testing import (
     GRAFANA_AGENT_APP,
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_logging,
     assert_path_reachable_through_ingress,
     deploy_and_assert_grafana_agent,
     deploy_and_integrate_service_mesh_charms,
     get_http_response,
 )
+from lightkube.generic_resource import create_namespaced_resource
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -36,6 +40,22 @@ HEADERS = {
 }
 HTTP_PATH = "/jupyter/"
 EXPECTED_RESPONSE_TEXT = "Jupyter Management UI"
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+# NOTE: Juju rejects application names whose final segment is all digits (e.g.
+# "istio-ingress-k8s-2"), so the suffix must contain a letter.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by jupyter-ui (see charm._configure_ambient_ingress).
+INGRESS_ROUTE_NAME = "http-route"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
 RETRY_120_SECONDS = tenacity.Retrying(
     stop=tenacity.stop_after_delay(120),
     wait=tenacity.wait_fixed(2),
@@ -127,6 +147,82 @@ async def test_ui_is_accessible(ops_test: OpsTest):
         expected_content_type="text/html",
         expected_response_text=EXPECTED_RESPONSE_TEXT,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_second_ingress(ops_test: OpsTest):
+    """Deploy a second istio-ingress-k8s and relate it to jupyter-ui.
+
+    jupyter-ui must accept more than one istio-ingress-route relation without erroring,
+    so it should remain active after the second ingress is related.
+    """
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        application_name=SECOND_INGRESS_APP,
+        channel=INGRESS_CHANNEL,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [SECOND_INGRESS_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    await ops_test.model.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{APP_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    await ops_test.model.wait_for_idle(
+        [APP_NAME, SECOND_INGRESS_APP],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=60 * 10,
+        idle_period=30,
+    )
+
+    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+
+async def test_httproute_attached_to_second_gateway(ops_test: OpsTest):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the jupyter-ui path to the jupyter-ui backend.
+    """
+    namespace = ops_test.model_name
+    client = lightkube.Client()
+
+    expected_route_name = (
+        f"{APP_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_120_SECONDS:
+        with attempt:
+            httproute = client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the jupyter-ui path to the jupyter-ui backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == HTTP_PATH
+    assert rule["backendRefs"][0]["name"] == APP_NAME
 
 
 async def get_unit_address(ops_test: OpsTest):

--- a/charms/jupyter-ui/tests/integration/test_charm_ambient.py
+++ b/charms/jupyter-ui/tests/integration/test_charm_ambient.py
@@ -134,8 +134,7 @@ async def test_deploy_and_relate_dependencies(ops_test: OpsTest):
     )
 
 
-@pytest.mark.abort_on_fail
-async def test_ui_is_accessible(ops_test: OpsTest):
+async def assert_ui_is_accessible(ops_test: OpsTest):
     """Verify that UI is accessible through the ingress gateway."""
     await assert_path_reachable_through_ingress(
         http_path=HTTP_PATH,
@@ -145,6 +144,12 @@ async def test_ui_is_accessible(ops_test: OpsTest):
         expected_content_type="text/html",
         expected_response_text=EXPECTED_RESPONSE_TEXT,
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway before the second ingress."""
+    await assert_ui_is_accessible(ops_test)
 
 
 @pytest.mark.abort_on_fail
@@ -221,6 +226,12 @@ async def test_httproute_attached_to_second_gateway(ops_test: OpsTest):
     rule = httproute.spec["rules"][0]
     assert rule["matches"][0]["path"]["value"] == HTTP_PATH
     assert rule["backendRefs"][0]["name"] == APP_NAME
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible_after_second_ingress(ops_test: OpsTest):
+    """Verify that UI is still accessible through the ingress gateway after the second ingress."""
+    await assert_ui_is_accessible(ops_test)
 
 
 async def get_unit_address(ops_test: OpsTest):

--- a/charms/jupyter-ui/tests/unit/test_operator.py
+++ b/charms/jupyter-ui/tests/unit/test_operator.py
@@ -13,7 +13,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from charmed_kubeflow_chisme.testing import ISTIO_INGRESS_K8S_APP, ISTIO_INGRESS_ROUTE_ENDPOINT
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from lightkube.models.core_v1 import (
     Affinity,
     NodeAffinity,
@@ -642,3 +646,50 @@ class TestCharm:
             harness.charm.model.unit.status,
             BlockedStatus,
         )
+
+    @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch("charm.JupyterUI.k8s_resource_handler")
+    def test_multiple_istio_ingress_route_relations_added(
+        self, k8s_resource_handler: MagicMock, harness: Harness
+    ):
+        """Test the charm handles more than one istio-ingress-route relation without erroring."""
+        # Arrange
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, f"{ISTIO_INGRESS_K8S_APP}-2")
+
+        # Act
+        harness.begin_with_initial_hooks()
+
+        # Assert
+        assert isinstance(
+            harness.charm.model.unit.status,
+            ActiveStatus,
+        )
+
+    @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch("charm.JupyterUI.k8s_resource_handler")
+    def test_each_istio_ingress_route_relation_receives_config(
+        self, k8s_resource_handler: MagicMock, harness: Harness
+    ):
+        """Test that an HTTPRoute config is submitted to every istio-ingress-route relation."""
+        # Arrange
+        rel_id_1 = harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
+        rel_id_2 = harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, f"{ISTIO_INGRESS_K8S_APP}-2")
+
+        # Act
+        harness.begin_with_initial_hooks()
+
+        # Assert
+        # Each relation's application databag should contain a valid config that
+        # defines the jupyter-ui HTTPRoute, proving the lib handles every ingress.
+        for rel_id in (rel_id_1, rel_id_2):
+            app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+            assert "config" in app_data
+
+            config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+            assert len(config.http_routes) == 1
+            http_route = config.http_routes[0]
+            assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+            assert http_route.matches[0].path.value == "/jupyter/"
+            assert http_route.backends[0].service == harness.charm.app.name
+            assert http_route.backends[0].port == harness.charm.model.config["port"]

--- a/charms/jupyter-ui/tests/unit/test_operator.py
+++ b/charms/jupyter-ui/tests/unit/test_operator.py
@@ -693,3 +693,6 @@ class TestCharm:
             assert http_route.matches[0].path.value == "/jupyter/"
             assert http_route.backends[0].service == harness.charm.app.name
             assert http_route.backends[0].port == harness.charm.model.config["port"]
+            # The route's parent (the Gateway listener referenced under parentRefs in
+            # the HTTPRouteSpec) should be the expected HTTP listener.
+            assert http_route.listener.name == "http-80"

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

Note: this PR will be replicated to all our charm that relate to `istio-ingress-route`, once approved