### PR TITLE
chore: use == to pin a version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ optional = true
 
 [tool.poetry.group.integration.dependencies]
 juju = "<4.0"
-blinker = "===1.7.0"
+blinker = "==1.7.0"
 lightkube = "^0.15.6"
 pytest = "^8.3.4"
 pytest-operator = "^0.38.0"


### PR DESCRIPTION
As far as I can tell, poetry does not support `===` for specifying versions. I assume this is a typo for `==`.